### PR TITLE
feat(frontend): refactor API contracts with backward compatibility

### DIFF
--- a/README_FRONTEND_PLAN.md
+++ b/README_FRONTEND_PLAN.md
@@ -1,244 +1,102 @@
-# README_FRONTEND_PLAN
+# Kế hoạch Frontend cho Nền tảng IELTS Tự học dùng AI
 
-## 1. Overview of Major Changes
+## 1. Mục tiêu sản phẩm
 
-The backend moved to a stricter metadata-first contract with standardized question handling. The biggest frontend-impacting shifts are:
+- Chuyển trải nghiệm từ mô hình lớp học truyền thống sang mô hình tự học cá nhân hóa.
+- Đặt AI làm trung tâm cho các luồng học tập: gợi ý lộ trình, chấm Writing/Speaking tức thì, theo dõi tiến độ.
+- Tích hợp rõ cơ chế Credits/Packages để người dùng hiểu chi phí và giá trị trước khi sử dụng tính năng nâng cao.
+- Bổ sung luồng "On-Demand Review Ticket" để người dùng mua chấm chữa thủ công từ giáo viên freelance.
 
-1. Endpoint contracts changed across auth, tests, answers, forum, vocab, grammar, statistics, and teacher flows, so existing service assumptions are no longer safe.
-2. Question logic is now schema-driven (14 question types), with strong validation and stricter payload requirements from [ielts_training_app/docs/metadata/schema-reference.md](../ielts_training_app/docs/metadata/schema-reference.md).
-3. Completion questions now require standardized blank placeholders like [1], [2] per [ielts_training_app/docs/metadata/blank-patterns.md](../ielts_training_app/docs/metadata/blank-patterns.md) and [ielts_training_app/docs/question-types/completion-types.md](../ielts_training_app/docs/question-types/completion-types.md).
-4. Renderer behavior changed for grouped completion/table/flowchart modes and dual answer input modes, documented in [ielts_training_app/docs/frontend/renderer-guide.md](../ielts_training_app/docs/frontend/renderer-guide.md).
-5. Teacher authoring payloads must send metadata correctly per type (no legacy answers-style payload), documented in [ielts_training_app/docs/frontend/teacher-guide.md](../ielts_training_app/docs/frontend/teacher-guide.md).
-6. Validation errors are now contract-critical and must be parsed/displayed correctly per [ielts_training_app/docs/api/validation-errors.md](../ielts_training_app/docs/api/validation-errors.md).
+## 2. Định vị giao diện
 
-## 2. List of Affected Files
+- Hướng tới trải nghiệm "Self-Study Command Center":
+  - Ưu tiên dashboard cá nhân theo mục tiêu band.
+  - Luồng thao tác ngắn, rõ, ít rào cản.
+  - Mọi trang quan trọng đều thể hiện trạng thái tín dụng (credits), tiến độ và gợi ý bước tiếp theo.
 
-### Core service and auth foundation
+## 3. Nhóm người dùng và nhu cầu
 
-- [src/services/axios.custom.js](src/services/axios.custom.js)
-- [src/services/apiAuth.js](src/services/apiAuth.js)
-- [src/context/authContext.jsx](src/context/authContext.jsx)
-- [src/context/auth/protectedRoute.jsx](src/context/auth/protectedRoute.jsx)
+### USER (học viên tự học)
 
-### Test lifecycle and renderer
+- Cần biết học gì hôm nay, học bao lâu, ưu tiên kỹ năng nào.
+- Cần phản hồi nhanh sau khi nộp bài.
+- Cần minh bạch credits trước khi chấm AI nâng cao hoặc gọi giáo viên chấm lại.
 
-- [src/services/apiDoTest.js](src/services/apiDoTest.js)
-- [src/services/apiTest.js](src/services/apiTest.js)
-- [src/Pages/client/test/testReview.jsx](src/Pages/client/test/testReview.jsx)
-- [src/Pages/client/test/testDetail.jsx](src/Pages/client/test/testDetail.jsx)
-- [src/components/test/Detail/QuestionRenderer.jsx](src/components/test/Detail/QuestionRenderer.jsx)
-- [src/components/test/Detail/RenderFillBlank.jsx](src/components/test/Detail/RenderFillBlank.jsx)
-- [src/components/test/Detail/RenderMatching.jsx](src/components/test/Detail/RenderMatching.jsx)
-- [src/components/test/Detail/RenderLabeling.jsx](src/components/test/Detail/RenderLabeling.jsx)
-- [src/components/test/Detail/RenderMCQ.jsx](src/components/test/Detail/RenderMCQ.jsx)
-- [src/components/test/Detail/RenderTFNG.jsx](src/components/test/Detail/RenderTFNG.jsx)
-- [src/components/test/Detail/RenderYesNoNotGiven.jsx](src/components/test/Detail/RenderYesNoNotGiven.jsx)
-- [src/components/test/Detail/RenderShortAnswer.jsx](src/components/test/Detail/RenderShortAnswer.jsx)
-- [src/components/test/type/listening.jsx](src/components/test/type/listening.jsx)
-- [src/components/test/type/reading.jsx](src/components/test/type/reading.jsx)
-- [src/components/test/type/writing.jsx](src/components/test/type/writing.jsx)
-- [src/components/test/type/speaking.jsx](src/components/test/type/speaking.jsx)
+### TEACHER (freelance reviewer/moderator)
 
-### Teacher authoring
+- Cần bảng hàng đợi ticket toàn cục dễ lọc và dễ nhận việc.
+- Cần trang xử lý ticket nhanh, có rubric rõ, hỗ trợ nhập feedback chuẩn hóa.
+- Cần theo dõi thu nhập và lịch sử ticket đã hoàn tất.
 
-- [src/components/test/teacher/Detail/FillBlankForm.jsx](src/components/test/teacher/Detail/FillBlankForm.jsx)
-- [src/components/test/teacher/Detail/MCQForm.jsx](src/components/test/teacher/Detail/MCQForm.jsx)
-- [src/components/test/teacher/Detail/MatchingForm.jsx](src/components/test/teacher/Detail/MatchingForm.jsx)
-- [src/components/test/teacher/Detail/LabelingForm.jsx](src/components/test/teacher/Detail/LabelingForm.jsx)
-- [src/components/test/teacher/Detail/TFNGForm.jsx](src/components/test/teacher/Detail/TFNGForm.jsx)
-- [src/components/test/teacher/Detail/YesNoNotGivenForm.jsx](src/components/test/teacher/Detail/YesNoNotGivenForm.jsx)
-- [src/Pages/teacher/test/testCreate.jsx](src/Pages/teacher/test/testCreate.jsx)
-- [src/Pages/teacher/test/testEdit.jsx](src/Pages/teacher/test/testEdit.jsx)
-- [src/Pages/teacher/test/testManager.jsx](src/Pages/teacher/test/testManager.jsx)
+### ADMIN
 
-### Feature modules and dashboard
+- Cần trang cấu hình gói dịch vụ, credits, quy tắc moderation.
+- Cần dashboard giám sát chất lượng chấm, tỷ lệ khiếu nại, và hiệu suất thị trường ticket.
 
-- [src/services/apiStatistics.js](src/services/apiStatistics.js)
-- [src/Pages/client/homePage.jsx](src/Pages/client/homePage.jsx)
-- [src/services/apiVocab.js](src/services/apiVocab.js)
-- [src/Pages/client/vocabulary.jsx](src/Pages/client/vocabulary.jsx)
-- [src/components/Vocab/FlashcardModal.jsx](src/components/Vocab/FlashcardModal.jsx)
-- [src/services/apiGrammar.js](src/services/apiGrammar.js)
-- [src/Pages/client/grammar.jsx](src/Pages/client/grammar.jsx)
-- [src/services/apiForum.js](src/services/apiForum.js)
-- [src/Pages/client/statistic.jsx](src/Pages/client/statistic.jsx)
-- [src/components/Forum/Forum/ForumBoard.jsx](src/components/Forum/Forum/ForumBoard.jsx)
-- [src/components/Forum/Forum/PostItem.jsx](src/components/Forum/Forum/PostItem.jsx)
-- [src/components/Forum/Forum/CommentList.jsx](src/components/Forum/Forum/CommentList.jsx)
-- [src/services/apiUser.js](src/services/apiUser.js)
-- [src/components/ui/navBar/profileModal.jsx](src/components/ui/navBar/profileModal.jsx)
-- [src/components/ui/navBar/StreakWidget.jsx](src/components/ui/navBar/StreakWidget.jsx)
-- [src/components/ui/navBar/xPWidget.jsx](src/components/ui/navBar/xPWidget.jsx)
-- [src/Pages/teacher/userList.jsx](src/Pages/teacher/userList.jsx)
+## 4. Luồng cốt lõi cần ưu tiên triển khai
 
-## 3. Implementation Plan (Phases)
+1. Luồng tự học bằng AI
+- Từ Dashboard -> Nhận kế hoạch ngày/tuần -> Làm bài -> Nhận chấm tức thì -> Cập nhật tiến độ.
 
-### Phase 1: Contract Baseline + Core API Services
+2. Luồng mua và dùng credits
+- Từ trang Pricing/Credits -> Chọn gói -> Thanh toán -> Cập nhật số dư -> Dùng vào tính năng cao cấp.
 
-**Objective:** Make the app contract-safe at service level before touching UI logic.
+3. Luồng On-Demand Review Ticket
+- Sau khi AI chấm -> Người dùng bấm yêu cầu chấm lại -> Trừ credits -> Tạo ticket -> Theo dõi trạng thái ticket.
 
-**Files to modify and detailed changes:**
+4. Luồng nhận và xử lý ticket của TEACHER
+- Teacher mở Global Queue -> Nhận ticket -> Chấm theo rubric -> Gửi feedback -> Hoàn tất và ghi nhận commission.
 
-1. Update endpoint paths, payload shapes, and response mapping in service files:
-   - [src/services/apiAuth.js](src/services/apiAuth.js)
-   - [src/services/apiDoTest.js](src/services/apiDoTest.js)
-   - [src/services/apiTest.js](src/services/apiTest.js)
-   - [src/services/apiStatistics.js](src/services/apiStatistics.js)
-   - [src/services/apiVocab.js](src/services/apiVocab.js)
-   - [src/services/apiForum.js](src/services/apiForum.js)
-   - [src/services/apiGrammar.js](src/services/apiGrammar.js)
-   - [src/services/apiUser.js](src/services/apiUser.js)
-2. Harden token refresh/introspect assumptions in:
-   - [src/services/axios.custom.js](src/services/axios.custom.js)
-   - [src/context/authContext.jsx](src/context/authContext.jsx)
-   - [src/context/auth/protectedRoute.jsx](src/context/auth/protectedRoute.jsx)
-3. Add a temporary compatibility mapper in service return values to keep old UI running while later phases migrate components.
+## 5. Danh sách màn hình frontend
 
-**Testing checklist after Phase 1:**
+- Dashboard tự học (USER)
+- Trang làm bài Writing/Speaking
+- Trang kết quả AI + lịch sử phản hồi
+- Trang Pricing, Subscription và Credits
+- Trang tạo và theo dõi On-Demand Review Ticket
+- Teacher Global Queue
+- Teacher Review Workspace
+- Teacher Earnings
+- Admin Control Panel (gói cước, moderation, analytics)
 
-1. App boots and routes render without blocking errors.
-2. Login, refresh-token retry, logout, and protected route access all work.
-3. At least one GET call and one mutation per major service family returns parsed data without runtime exceptions.
-4. Validation error payloads from backend show stable user-facing messages.
+## 6. Kế hoạch triển khai theo giai đoạn
 
-### Phase 2: Renderer + Teacher Form Foundations
+### Giai đoạn 1: Nền tảng tự học
 
-**Objective:** Align question rendering/submission and authoring payloads with new metadata rules.
+- Hoàn thiện dashboard tự học và trang lịch sử tiến độ.
+- Chuẩn hóa UI cho nộp bài Writing/Speaking và hiển thị kết quả AI.
+- Hoàn tất quản lý trạng thái loading/error/empty cho các trang chính.
 
-**Files to modify and detailed changes:**
+### Giai đoạn 2: Monetization
 
-1. Update renderer pipeline in:
-   - [src/components/test/Detail/QuestionRenderer.jsx](src/components/test/Detail/QuestionRenderer.jsx)
-   - [src/components/test/Detail/RenderFillBlank.jsx](src/components/test/Detail/RenderFillBlank.jsx)
-   - Other question detail renderers
-   to parse standardized [n] placeholders and grouped content modes.
-2. Update answer capture in:
-   - [src/components/test/type/listening.jsx](src/components/test/type/listening.jsx)
-   - [src/components/test/type/reading.jsx](src/components/test/type/reading.jsx)
-   - [src/components/test/type/writing.jsx](src/components/test/type/writing.jsx)
-   - [src/components/test/type/speaking.jsx](src/components/test/type/speaking.jsx)
-   to support dual-mode answerText and matching_key behavior.
-3. Refactor teacher forms in:
-   - [src/components/test/teacher/Detail/FillBlankForm.jsx](src/components/test/teacher/Detail/FillBlankForm.jsx)
-   - [src/components/test/teacher/Detail/MCQForm.jsx](src/components/test/teacher/Detail/MCQForm.jsx)
-   - [src/components/test/teacher/Detail/MatchingForm.jsx](src/components/test/teacher/Detail/MatchingForm.jsx)
-   - [src/components/test/teacher/Detail/LabelingForm.jsx](src/components/test/teacher/Detail/LabelingForm.jsx)
-   - [src/components/test/teacher/Detail/TFNGForm.jsx](src/components/test/teacher/Detail/TFNGForm.jsx)
-   - [src/components/test/teacher/Detail/YesNoNotGivenForm.jsx](src/components/test/teacher/Detail/YesNoNotGivenForm.jsx)
-   to emit metadata-first payloads with client-side pre-validation.
+- Xây trang Pricing và Credits Wallet.
+- Tích hợp kiểm tra entitlement theo gói Freemium/Pro.
+- Thêm cảnh báo trước khi tiêu credits ở các thao tác premium.
 
-**Testing checklist after Phase 2:**
+### Giai đoạn 3: Marketplace giáo viên
 
-1. Teacher can create one question each for MCQ, matching, completion, diagram, TFNG/YNNG, short answer with valid metadata.
-2. Student renderer can display and submit those created questions.
-3. Submission payload includes correct answer shape by input mode.
-4. App remains fully runnable for non-test areas.
+- Xây luồng tạo ticket từ bài AI đã chấm.
+- Xây Global Queue cho TEACHER và trang xử lý ticket.
+- Bổ sung trạng thái ticket đầy đủ: mới, đã nhận, đang xử lý, hoàn tất, khiếu nại.
 
-### Phase 3: Isolated Feature Tracks (Parallel, Independent)
+### Giai đoạn 4: Vận hành và tối ưu
 
-**Objective:** Migrate low-coupling modules while preserving app stability.
+- Hoàn thiện trang quản trị cho ADMIN.
+- Bổ sung dashboard chất lượng chấm và KPI doanh thu.
+- Tối ưu UX mobile cho các luồng chính.
 
-**Files to modify and detailed changes:**
+## 7. KPI đề xuất cho frontend
 
-1. Vocabulary track:
-   - [src/services/apiVocab.js](src/services/apiVocab.js)
-   - [src/Pages/client/vocabulary.jsx](src/Pages/client/vocabulary.jsx)
-   - [src/components/Vocab/FlashcardModal.jsx](src/components/Vocab/FlashcardModal.jsx)
-2. Grammar track:
-   - [src/services/apiGrammar.js](src/services/apiGrammar.js)
-   - [src/Pages/client/grammar.jsx](src/Pages/client/grammar.jsx)
-3. Forum track:
-   - [src/services/apiForum.js](src/services/apiForum.js)
-   - [src/Pages/client/statistic.jsx](src/Pages/client/statistic.jsx)
-   - [src/components/Forum/Forum/ForumBoard.jsx](src/components/Forum/Forum/ForumBoard.jsx)
-   - [src/components/Forum/Forum/PostItem.jsx](src/components/Forum/Forum/PostItem.jsx)
-   - [src/components/Forum/Forum/CommentList.jsx](src/components/Forum/Forum/CommentList.jsx)
+- Tỷ lệ hoàn thành phiên học tự đề xuất bởi AI.
+- Tỷ lệ chuyển đổi từ Freemium sang Pro.
+- Tỷ lệ người dùng mua credits lần 2.
+- Thời gian trung bình từ tạo ticket đến lúc hoàn tất review.
+- Mức độ hài lòng của người dùng sau khi nhận feedback từ AI và từ giáo viên.
 
-**Testing checklist after Phase 3:**
+## 8. Tiêu chí hoàn thành
 
-1. Vocabulary CRUD and AI suggestion fallback work.
-2. Grammar category/item CRUD works.
-3. Forum thread/post/comment/like flows including multipart post updates work.
-4. App is still runnable and testable even if test module is not yet fully migrated.
+- Người dùng mới có thể bắt đầu học trong dưới 3 phút.
+- Luồng mua credits và dùng credits không gây nhầm lẫn.
+- Luồng tạo ticket và theo dõi ticket hoạt động xuyên suốt trên desktop và mobile.
+- Teacher có thể xử lý ticket với thao tác tối giản và phản hồi đúng rubric.
 
-### Phase 4: User Surface + Statistics Aggregation
-
-**Objective:** Migrate profile/admin/dashboard cross-read logic before final test lifecycle migration.
-
-**Files to modify and detailed changes:**
-
-1. Update profile/streak/xp/user admin assumptions in:
-   - [src/services/apiUser.js](src/services/apiUser.js)
-   - [src/components/ui/navBar/profileModal.jsx](src/components/ui/navBar/profileModal.jsx)
-   - [src/components/ui/navBar/StreakWidget.jsx](src/components/ui/navBar/StreakWidget.jsx)
-   - [src/components/ui/navBar/xPWidget.jsx](src/components/ui/navBar/xPWidget.jsx)
-   - [src/Pages/teacher/userList.jsx](src/Pages/teacher/userList.jsx)
-2. Migrate dashboard aggregation in:
-   - [src/services/apiStatistics.js](src/services/apiStatistics.js)
-   - [src/Pages/client/homePage.jsx](src/Pages/client/homePage.jsx)
-   with partial-failure handling for multi-call loads.
-
-**Testing checklist after Phase 4:**
-
-1. Profile fetch/update works and navbar widgets do not crash.
-2. Teacher user list CRUD works.
-3. Dashboard cards/charts/targets load correctly with graceful fallback if one endpoint fails.
-4. Recommendation clicks navigate safely (even if test flow final migration is pending).
-
-### Phase 5: Test Lifecycle (Sequential, High-Risk Core)
-
-**Objective:** Complete the full student and teacher test flows with no session-breaking gaps.
-
-**Files to modify and detailed changes:**
-
-1. Subphase 5A (list + start):
-   - [src/Pages/client/test/testReview.jsx](src/Pages/client/test/testReview.jsx)
-   - [src/services/apiTest.js](src/services/apiTest.js)
-   - [src/services/apiDoTest.js](src/services/apiDoTest.js)
-   Persist and safely restore test session identity to avoid refresh-loss blockers.
-2. Subphase 5B (runner + submit):
-   - [src/Pages/client/test/testDetail.jsx](src/Pages/client/test/testDetail.jsx)
-   - Test type components
-   - Renderer detail components
-   - Answer serialization paths
-3. Subphase 5C (review replay):
-   - [src/components/test/SimpleResultModal.jsx](src/components/test/SimpleResultModal.jsx)
-   - Question review rendering paths
-   - Result-and-answers mapping
-4. Subphase 5D (teacher create/edit):
-   - [src/Pages/teacher/test/testCreate.jsx](src/Pages/teacher/test/testCreate.jsx)
-   - [src/Pages/teacher/test/testEdit.jsx](src/Pages/teacher/test/testEdit.jsx)
-   - [src/Pages/teacher/test/testManager.jsx](src/Pages/teacher/test/testManager.jsx)
-   - Teacher detail forms
-
-**Testing checklist after Phase 5:**
-
-1. Student path: list tests -> start -> answer -> submit -> view score -> open review.
-2. Teacher path: create/edit/delete test with nested entities and multiple question types.
-3. Test session survives refresh/re-entry without unrecoverable state.
-4. No blocking UI/runtime errors remain in test and dashboard integration.
-
-### Phase 6: Hardening + Cutover Cleanup
-
-**Objective:** Remove transitional compatibility logic and certify release-readiness.
-
-**Files to modify and detailed changes:**
-
-1. Remove temporary compatibility adapters introduced in Phase 1 from service modules.
-2. Clean dead code paths and normalize response parsing across components.
-3. Finalize migration documentation in the plan appendix and release checklist.
-
-**Testing checklist after Phase 6:**
-
-1. Full regression of auth, vocab, grammar, forum, profile/admin, statistics, test-taking, and teacher authoring.
-2. Validation-error UX review across all create/update forms.
-3. Smoke test on production-like environment variables and network latency scenarios.
-
-## 4. Risks & Notes
-
-1. Highest risk area is test execution and answer serialization in [src/services/apiDoTest.js](src/services/apiDoTest.js) and [src/services/apiTest.js](src/services/apiTest.js); small contract drift here can break core flows.
-2. Refresh-token response shape drift in [src/services/axios.custom.js](src/services/axios.custom.js) can cause global auth failure.
-3. Grouped completion rendering and [n] placeholder parsing errors in [src/components/test/Detail/RenderFillBlank.jsx](src/components/test/Detail/RenderFillBlank.jsx) can silently corrupt answer capture.
-4. Teacher form payload mismatches (especially MCQ indexes, TFNG/YNNG enums, diagram coordinates) are likely to trigger frequent 400s unless pre-validation is added.
-5. Statistics page is multi-endpoint and tightly coupled to test data; partial failure handling is required to keep [src/Pages/client/homePage.jsx](src/Pages/client/homePage.jsx) runnable during staged migration.
-6. Session continuity for active tests should be explicitly decided early; using only navigation state is fragile.

--- a/README_FRONTEND_REFACTOR_STABILITY_2026-04-20.md
+++ b/README_FRONTEND_REFACTOR_STABILITY_2026-04-20.md
@@ -1,0 +1,388 @@
+# Frontend Refactor README (Stability First)
+
+Ngày: 2026-04-20  
+Phạm vi: Chỉ frontend, bám theo các hàm/route backend đang có (không thêm endpoint mới).
+
+## 1. Mục tiêu
+
+Tài liệu này tổng hợp các mismatch đã xác minh giữa frontend và backend để refactor frontend chạy ổn định.
+
+- Chỉ dùng contract backend hiện có.
+- Không đề xuất feature mới.
+- Chưa sửa code trong tài liệu này, chỉ lập kế hoạch để duyệt trước.
+
+## 2. Kết luận nhanh
+
+Frontend hiện đang trộn 2 contract:
+
+- Contract cũ: `groupOfQuestions`, `answers`, `correct_answers`, `finish-test`, `answer_text`, `submission_text`, ...
+- Contract mới backend hiện tại: `questionGroups`, `metadata`, `submit-reading-listening`, `answerPayload`, `submissionText`, ...
+
+Hệ quả: nhiều luồng sẽ gặp 404/400 hoặc parse sai dữ liệu, đặc biệt là submit Reading/Listening, teacher test editor, và result modal.
+
+## 3. Findings đã xác minh (ưu tiên theo mức độ)
+
+## 3.1 Blocking
+
+### B1) Reading/Listening submit đang gọi endpoint đã đổi và payload đã cũ
+
+Bằng chứng:
+- FE route cũ: `IELTS-training-website/src/services/apiDoTest.js:5`
+- FE route cũ finish-test: `IELTS-training-website/src/services/apiDoTest.js:20`
+- FE route cũ lấy answers theo test result: `IELTS-training-website/src/services/apiDoTest.js:36`
+- FE route cũ reset-test với 2 param: `IELTS-training-website/src/services/apiDoTest.js:48`
+- FE call submit (reading): `IELTS-training-website/src/components/test/type/reading.jsx:399`, `IELTS-training-website/src/components/test/type/reading.jsx:406`
+- FE call submit (listening): `IELTS-training-website/src/components/test/type/listening.jsx:423`, `IELTS-training-website/src/components/test/type/listening.jsx:430`
+- FE payload cũ (`answerText`, `userAnswerType`, `matching_key`, `matching_value`):
+  - `IELTS-training-website/src/components/test/type/reading.jsx:354`
+  - `IELTS-training-website/src/components/test/type/reading.jsx:355`
+  - `IELTS-training-website/src/components/test/type/reading.jsx:356`
+  - `IELTS-training-website/src/components/test/type/listening.jsx:379`
+  - `IELTS-training-website/src/components/test/type/listening.jsx:380`
+  - `IELTS-training-website/src/components/test/type/listening.jsx:381`
+- BE save-progress route: `ielts_training_app/src/module/user-answer/user-answer.controller.ts:16`
+- BE submit route mới: `ielts_training_app/src/module/user-test-result/user-test-result.controller.ts:128`
+- BE DTO answer mới (`answerType`, `answerPayload`): `ielts_training_app/src/module/user-answer/dto/create-user-answer.dto.ts:17`, `ielts_training_app/src/module/user-answer/dto/create-user-answer.dto.ts:25`
+- BE DTO submit mới: `ielts_training_app/src/module/user-test-result/dto/submit-test.dto.ts:63`, `ielts_training_app/src/module/user-test-result/dto/submit-test.dto.ts:81`
+
+Rủi ro:
+- 404/400 khi submit bài.
+- Dữ liệu answers không được chấm điểm theo pipeline mới.
+
+### B2) Frontend đang phụ thuộc schema câu hỏi cũ, backend đã chuyển sang `metadata`
+
+Bằng chứng:
+- FE map schema cũ (`typeQuestion`, `question`, `answer_text`, `correct_answers`):
+  - `IELTS-training-website/src/components/test/type/reading.jsx:48`
+  - `IELTS-training-website/src/components/test/type/reading.jsx:50`
+  - `IELTS-training-website/src/components/test/type/reading.jsx:53`
+  - `IELTS-training-website/src/components/test/type/reading.jsx:62`
+  - `IELTS-training-website/src/components/test/type/listening.jsx:49`
+  - `IELTS-training-website/src/components/test/type/listening.jsx:51`
+- FE vẫn dùng `groupOfQuestions`: `IELTS-training-website/src/components/test/type/reading.jsx:195`, `IELTS-training-website/src/components/test/type/listening.jsx:206`
+- FE renderer phụ thuộc `correct_answers` + `type_question`:
+  - `IELTS-training-website/src/components/test/Detail/QuestionRenderer.jsx:50`
+  - `IELTS-training-website/src/components/test/Detail/QuestionRenderer.jsx:75`
+  - `IELTS-training-website/src/components/test/Detail/QuestionRenderer.jsx:112`
+- BE trả `questionGroups` + `metadata`: `ielts_training_app/src/module/test/test.service.ts:375`, `ielts_training_app/src/module/test/test.service.ts:397`
+- BE DTO question mới (`idQuestionGroup`, `questionNumber`, `questionType`, `metadata`):
+  - `ielts_training_app/src/module/question/dto/create-question.dto.ts:16`
+  - `ielts_training_app/src/module/question/dto/create-question.dto.ts:27`
+  - `ielts_training_app/src/module/question/dto/create-question.dto.ts:36`
+  - `ielts_training_app/src/module/question/dto/create-question.dto.ts:54`
+
+Rủi ro:
+- Render sai/không có dữ liệu cho Reading/Listening.
+- Submit answer không map đúng về `answerPayload`.
+
+### B3) Teacher test editor đang gửi payload cũ, không khớp question contract mới
+
+Bằng chứng:
+- FE payload cũ dùng `idGroupOfQuestions`, `numberQuestion`, `answers[]`:
+  - `IELTS-training-website/src/components/test/teacher/Detail/MCQForm.jsx:210`
+  - `IELTS-training-website/src/components/test/teacher/Detail/TFNGForm.jsx:124`
+  - `IELTS-training-website/src/components/test/teacher/Detail/FillBlankForm.jsx:383`
+- FE gọi batch update route không tồn tại ở backend: `IELTS-training-website/src/services/apiTest.js:184`
+- BE chỉ có create-many + update-single:
+  - `ielts_training_app/src/module/question/question.controller.ts:29`
+  - `ielts_training_app/src/module/question/question.controller.ts:46`
+- FE gọi `createManyQuestion`/`updateManyQuestionAPI` trên nhiều form:
+  - `IELTS-training-website/src/components/test/teacher/Detail/MCQForm.jsx:260`
+  - `IELTS-training-website/src/components/test/teacher/Detail/MCQForm.jsx:279`
+  - `IELTS-training-website/src/components/test/teacher/Detail/TFNGForm.jsx:144`
+  - `IELTS-training-website/src/components/test/teacher/Detail/TFNGForm.jsx:217`
+
+Rủi ro:
+- Tạo/sửa question fail toàn bộ sau khi validate metadata.
+
+### B4) Namespace route question group đã đổi (`group-of-questions` -> `question-group`)
+
+Bằng chứng:
+- FE route cũ:
+  - `IELTS-training-website/src/services/apiTest.js:76`
+  - `IELTS-training-website/src/services/apiTest.js:128`
+  - `IELTS-training-website/src/services/apiTest.js:145`
+  - `IELTS-training-website/src/services/apiTest.js:168`
+- BE route mới:
+  - `ielts_training_app/src/module/question-group/question-group.controller.ts:19`
+  - `ielts_training_app/src/module/question-group/question-group.controller.ts:23`
+  - `ielts_training_app/src/module/question-group/question-group.controller.ts:54`
+  - `ielts_training_app/src/module/question-group/question-group.controller.ts:90`
+
+Rủi ro:
+- 404 ở create/get/update/delete question group.
+
+### B5) Result modal đang parse field cũ (snake_case, singular collections)
+
+Bằng chứng:
+- FE lấy writing text cũ: `IELTS-training-website/src/components/test/SimpleResultModal.jsx:356`, `IELTS-training-website/src/components/test/SimpleResultModal.jsx:441`
+- FE đọc collection cũ: `IELTS-training-website/src/components/test/SimpleResultModal.jsx:642`, `IELTS-training-website/src/components/test/SimpleResultModal.jsx:643`
+- FE đọc điểm cũ: `IELTS-training-website/src/components/test/SimpleResultModal.jsx:725`, `IELTS-training-website/src/components/test/SimpleResultModal.jsx:748`
+- FE vẫn đọc `groupOfQuestions`: `IELTS-training-website/src/components/test/SimpleResultModal.jsx:590`
+- BE trả `writingSubmissions`, `speakingSubmissions`, `userAnswers`:
+  - `ielts_training_app/src/module/user-test-result/user-test-result.service.ts:663`
+  - `ielts_training_app/src/module/user-test-result/user-test-result.service.ts:685`
+  - `ielts_training_app/src/module/user-test-result/user-test-result.service.ts:698`
+- BE dùng camelCase score fields (`bandScore`, `totalCorrect`):
+  - `ielts_training_app/src/module/user-test-result/user-test-result.service.ts:333`
+  - `ielts_training_app/src/module/user-test-result/user-test-result.service.ts:334`
+
+Rủi ro:
+- Modal hiển thị sai hoặc trạng thái rỗng dù đã có kết quả.
+
+## 3.2 High
+
+### H1) Writing finish payload key sai: `submission_text` -> phải là `submissionText`
+
+Bằng chứng:
+- FE: `IELTS-training-website/src/components/test/type/writing.jsx:324`
+- BE DTO: `ielts_training_app/src/module/user-test-result/dto/finish-test-writing.dto.ts:19`
+- BE xử lý theo key mới: `ielts_training_app/src/module/user-test-result/user-test-result.service.ts:760`
+
+Rủi ro:
+- Writing submissions bị bỏ qua khi finish.
+
+### H2) Create writing submission route thiếu `idTestResult`
+
+Bằng chứng:
+- FE: `IELTS-training-website/src/services/apiWriting.js:15`
+- BE: `ielts_training_app/src/module/user-writing-submission/user-writing-submission.controller.ts:22`
+
+Rủi ro:
+- 404 nếu API này được dùng.
+
+### H3) Speaking task list route mismatch
+
+Bằng chứng:
+- FE: `IELTS-training-website/src/services/apiSpeaking.js:23`
+- BE: `ielts_training_app/src/module/speaking-task/speaking-task.controller.ts:26`
+
+Rủi ro:
+- 404 với function fetch speaking tasks (hiện tại có thể chưa được gọi trực tiếp).
+
+### H4) Users delete route mismatch
+
+Bằng chứng:
+- FE: `IELTS-training-website/src/services/apiUser.js:27`
+- BE: `ielts_training_app/src/module/users/users.controller.ts:87`
+
+Rủi ro:
+- Xóa user thất bại ở trang user list.
+
+### H5) Forum delete cần `idUser` trong body, frontend không gửi
+
+Bằng chứng:
+- FE delete endpoints:
+  - `IELTS-training-website/src/services/apiForum.js:104`
+  - `IELTS-training-website/src/services/apiForum.js:110`
+  - `IELTS-training-website/src/services/apiForum.js:116`
+- FE call sites không truyền body:
+  - `IELTS-training-website/src/components/Forum/ThreadSidebar/ThreadItem.jsx:22`
+  - `IELTS-training-website/src/components/Forum/Forum/PostItem.jsx:75`
+  - `IELTS-training-website/src/components/Forum/Forum/CommentItem.jsx:78`
+- BE controllers lấy `idUser` từ body:
+  - `ielts_training_app/src/module/forum-threads/forum-threads.controller.ts:49`
+  - `ielts_training_app/src/module/forum-post/forum-post.controller.ts:124`
+  - `ielts_training_app/src/module/forum-comment/forum-comment.controller.ts:49`
+
+Rủi ro:
+- 403/400 khi delete dù user là owner.
+
+### H6) Auth resend OTP type mismatch
+
+Bằng chứng:
+- FE call không có type hoặc type sai enum (`RESET_PASSWORD`):
+  - `IELTS-training-website/src/Pages/client/auth/OTP.jsx:52`
+  - `IELTS-training-website/src/Pages/client/auth/OTP.jsx:54`
+- BE contract: `type: 'OTP' | 'RESET_LINK'`:
+  - `ielts_training_app/src/auth/auth.controller.ts:58`
+- BE service có branch theo enum, có thể trả `otpRecord` undefined nếu type sai:
+  - `ielts_training_app/src/auth/auth.service.ts:107`
+  - `ielts_training_app/src/auth/auth.service.ts:131`
+
+Rủi ro:
+- Luồng resend OTP reset password không ổn định.
+
+### H7) Google callback không trả `refreshToken` query, FE vẫn lưu giá trị này
+
+Bằng chứng:
+- FE đọc query `refreshToken`: `IELTS-training-website/src/Pages/client/auth/login.jsx:28`
+- FE set cookie refreshToken từ query: `IELTS-training-website/src/Pages/client/auth/login.jsx:34`
+- BE redirect chỉ có token + user: `ielts_training_app/src/auth/auth.controller.ts:131`
+
+Rủi ro:
+- Cookie refresh token có thể rỗng/invalid sau login Google.
+
+## 3.3 Medium
+
+### M1) Param mismatch trên route testEdit
+
+Bằng chứng:
+- Route dùng `:id`: `IELTS-training-website/src/main.jsx:95`
+- Page đọc `idTest`: `IELTS-training-website/src/Pages/teacher/test/testEdit.jsx:11`
+- Có navigate sai path ở 1 nút: `IELTS-training-website/src/Pages/teacher/test/testCreate.jsx:45`
+
+Rủi ro:
+- Vào trang edit không lấy được test id trong một số flow.
+
+### M2) API stale không còn contract backend
+
+Bằng chứng:
+- FE stale endpoints:
+  - `IELTS-training-website/src/services/apiTest.js:93` (`/option/create-many-option`)
+  - `IELTS-training-website/src/services/apiTest.js:98` (`/answer/create-answer`)
+  - `IELTS-training-website/src/services/apiTest.js:103` (`/user-test/upsert-user-test`)
+- Không tìm thấy controller tương ứng trong backend modules hiện tại.
+
+Rủi ro:
+- Hàm để lại gây nhầm lẫn, dễ bị gọi nhầm khi mở rộng tính năng.
+
+### M3) Add vocabulary to topic đang post không body
+
+Bằng chứng:
+- FE: `IELTS-training-website/src/services/apiVocab.js:44`
+- BE cần body DTO: `ielts_training_app/src/module/vocabulary/vocabulary.controller.ts:52`, `ielts_training_app/src/module/vocabulary/vocabulary.controller.ts:55`
+
+Rủi ro:
+- 400 nếu hàm được sử dụng.
+
+## 4. Mapping contract cần chuyển (frontend)
+
+| Tính năng | Frontend hiện tại | Backend hiện tại (đúng) |
+|---|---|---|
+| Save progress R/L | `POST /user-answer/create-many-user-answers/:idUser/:idTestResult` | `POST /user-answer/save-progress/:idUser/:idTestResult` |
+| Submit R/L | `PATCH /user-test-result/finish-test/:idUser/:idTestResult` | `POST /user-test-result/submit-reading-listening/:idUser` |
+| Reset test | `DELETE /user-test-result/reset-test/:idUser/:idTestResult` | `DELETE /user-test-result/reset-test/:idTestResult` |
+| Question group base | `/group-of-questions/*` | `/question-group/*` |
+| Speaking task list | `/speaking-task/find-all-speaking-tasks/:idTest` | `/speaking-task/find-all-speaking-tasks-in-test/:idTest` |
+| Writing submission create | `/user-writing-submission/create-writing-submission` | `/user-writing-submission/create-writing-submission/:idTestResult` |
+| User delete | `DELETE /users/:id` | `DELETE /users/delete-user/:idUser` |
+
+## 5. Payload/field mapping cần chuyển
+
+## 5.1 Reading/Listening answer item
+
+Frontend cũ (đang dùng):
+- `idQuestion`
+- `answerText`
+- `userAnswerType`
+- `matching_key`
+- `matching_value`
+
+Backend mới (bắt buộc):
+- `idQuestion`
+- `answerType`
+- `answerPayload`
+
+Gợi ý mapping theo question type (dựa trên `metadata.type`):
+- `MULTIPLE_CHOICE` -> `{ type: 'MULTIPLE_CHOICE', selectedIndexes: number[] }`
+- `TRUE_FALSE_NOT_GIVEN` -> `{ type: 'TRUE_FALSE_NOT_GIVEN', answer: 'TRUE'|'FALSE'|'NOT_GIVEN' }`
+- `YES_NO_NOT_GIVEN` -> `{ type: 'YES_NO_NOT_GIVEN', answer: 'YES'|'NO'|'NOT_GIVEN' }`
+- Matching types -> `{ type: ..., selectedLabel: string }`
+- Fill/short/diagram -> `{ type: ..., answerText: string }`
+
+Reference schema:
+- `ielts_training_app/src/module/user-test-result/dto/submit-test.dto.ts:53`
+- `ielts_training_app/src/module/question/dto/create-question.dto.ts:54`
+
+## 5.2 Writing finish
+
+Frontend cũ:
+- `writingSubmissions[].submission_text`
+
+Backend mới:
+- `writingSubmissions[].submissionText`
+
+Reference:
+- `IELTS-training-website/src/components/test/type/writing.jsx:324`
+- `ielts_training_app/src/module/user-test-result/dto/finish-test-writing.dto.ts:19`
+
+## 5.3 Result fields
+
+Frontend parser cũ:
+- `band_score`, `total_correct`, `writingSubmission`, `speakingSubmission`, `submission_text`
+
+Backend mới:
+- `bandScore`, `totalCorrect`, `writingSubmissions`, `speakingSubmissions`, `submissionText`
+
+Reference:
+- `IELTS-training-website/src/components/test/SimpleResultModal.jsx:642`
+- `IELTS-training-website/src/components/test/SimpleResultModal.jsx:725`
+- `ielts_training_app/src/module/user-test-result/user-test-result.service.ts:663`
+- `ielts_training_app/src/module/user-test-result/user-test-result.service.ts:685`
+
+## 6. Kế hoạch refactor (thực hiện sau khi duyệt)
+
+### Phase 1 - Service layer alignment (1 source of truth)
+
+- Update `apiDoTest.js` theo contract mới:
+  - Đổi route save-progress.
+  - Bỏ route finish-test cũ.
+  - Thêm hàm submit-reading-listening theo DTO mới.
+  - Fix reset-test param.
+- Update `apiTest.js`:
+  - Đổi `group-of-questions` -> `question-group`.
+  - Đánh dấu deprecated cho `option`, `answer`, `user-test/upsert-user-test`, `update-many-questions`.
+- Update `apiWriting.js`, `apiSpeaking.js`, `apiUser.js`, `apiForum.js`, `apiVocab.js` theo findings.
+
+### Phase 2 - Reading/Listening runtime migration
+
+- Refactor builder answer payload -> `answerType` + `answerPayload`.
+- Chuyển luồng submit sang `submit-reading-listening`.
+- Dùng schema `questionGroups/questions/metadata` thay cho `groupOfQuestions/question/answers`.
+- Đảm bảo không swap tham số khi gọi API.
+
+### Phase 3 - Teacher test editor migration
+
+- Chuyển payload create/update question sang schema mới (`idQuestionGroup`, `questionNumber`, `questionType`, `metadata`).
+- Bỏ phụ thuộc answer endpoints cũ.
+- Đổi batch update: dùng loop `update-question/:idQuestion` (vì backend không có `update-many`).
+
+### Phase 4 - Result modal normalization
+
+- Viết normalizer cho reading/listening/writing/speaking từ response mới.
+- Update field map camelCase.
+- Giữ parser tương thích ngược cho dữ liệu cũ (nếu cần).
+
+### Phase 5 - Auth/User/Forum hardening
+
+- Fix enum OTP resend (`OTP`/`RESET_LINK`).
+- Google login: không set refresh token từ query nếu không có.
+- Fix route xóa user.
+- Forum delete thêm `{ data: { idUser } }` trong `API.delete`.
+
+## 7. Checklist test sau refactor
+
+Reading/Listening:
+- Start test -> save progress -> submit -> xem result modal.
+- Không 404 ở submit/save-progress/reset.
+- Band score hiển thị đúng.
+
+Teacher test editor:
+- Tạo/sửa/xóa question group.
+- Tạo/sửa question cho ít nhất 3 loại: MCQ, TFNG, FILL.
+- Không gọi route cũ `/answer/*`, `/option/*`, `/group-of-questions/*`.
+
+Writing/Speaking:
+- Writing finish gửi `submissionText` và nhận submissions có score.
+- Speaking finish và xem result modal.
+
+Auth/User/Forum:
+- Resend OTP cả register và reset password.
+- Login Google không tạo refresh token rỗng.
+- Delete user/forum thành công khi đúng owner.
+
+## 8. Gate để bắt đầu code refactor
+
+Nếu bạn đồng ý, bước tiếp theo là:
+
+1. Tạo PR refactor service layer trước (không đụng vào UI renderer).
+2. Refactor Reading/Listening + Result modal.
+3. Refactor Teacher editor.
+4. Chạy manual checklist mục 7.
+
+---
+
+Nếu cần, mình có thể tách thành 2 PR:
+- PR-A: API services + auth/user/forum fixes.
+- PR-B: Reading/Listening + Teacher editor + Result modal migration.

--- a/src/Pages/client/auth/OTP.jsx
+++ b/src/Pages/client/auth/OTP.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { motion } from "framer-motion";
+import { motion as Motion } from "framer-motion";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Shield, RefreshCw } from "lucide-react";
 import {
@@ -51,7 +51,7 @@ const OTP = () => {
       if (mode === "OTP") {
         await resendOtpAPI({ email });
       } else {
-        await resendOtpAPI({ email, type: "RESET_PASSWORD" });
+        await resendOtpAPI({ email, type: "RESET_LINK" });
       }
       alert("Đã gửi lại mã OTP!");
     } catch (error) {
@@ -70,7 +70,7 @@ const OTP = () => {
         <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-indigo-500/10 rounded-full blur-3xl" />
       </div>
 
-      <motion.div
+      <Motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
@@ -78,14 +78,14 @@ const OTP = () => {
       >
         {/* Logo */}
         <div className="text-center mb-8">
-          <motion.div
+          <Motion.div
             initial={{ scale: 0 }}
             animate={{ scale: 1 }}
             transition={{ delay: 0.2, type: "spring" }}
             className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-2xl shadow-lg shadow-blue-500/30 mb-4"
           >
             <Shield className="w-8 h-8 text-white" />
-          </motion.div>
+          </Motion.div>
           <h1 className="text-2xl font-bold text-white">Xác thực OTP</h1>
           <p className="text-slate-400 text-sm">Bảo mật tài khoản của bạn</p>
         </div>
@@ -144,7 +144,7 @@ const OTP = () => {
             </p>
           </div>
         </div>
-      </motion.div>
+      </Motion.div>
     </div>
   );
 };

--- a/src/Pages/client/auth/login.jsx
+++ b/src/Pages/client/auth/login.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { motion } from "framer-motion";
+import { motion as Motion } from "framer-motion";
 import { Eye, EyeOff, BookOpen, Mail, Lock } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import API from "@/services/axios.custom";
@@ -31,12 +31,14 @@ const Login = () => {
       const user = JSON.parse(decodeURIComponent(userParam));
       Cookies.set("accessToken", token);
       Cookies.set("user", JSON.stringify(user));
-      Cookies.set("refreshToken", refreshToken);
+      if (refreshToken) {
+        Cookies.set("refreshToken", refreshToken);
+      }
       setUser(user);
       setIsAuth(true);
       navigate("/");
     }
-  }, []);
+  }, [navigate, setIsAuth, setUser]);
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -75,7 +77,7 @@ const Login = () => {
         <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-indigo-500/10 rounded-full blur-3xl" />
       </div>
 
-      <motion.div
+      <Motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
@@ -83,14 +85,14 @@ const Login = () => {
       >
         {/* Logo */}
         <div className="text-center mb-8">
-          <motion.div
+          <Motion.div
             initial={{ scale: 0 }}
             animate={{ scale: 1 }}
             transition={{ delay: 0.2, type: "spring" }}
             className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-2xl shadow-lg shadow-blue-500/30 mb-4"
           >
             <BookOpen className="w-8 h-8 text-white" />
-          </motion.div>
+          </Motion.div>
           <h1 className="text-2xl font-bold text-white">AIELTS</h1>
           <p className="text-slate-400 text-sm">Đăng nhập để tiếp tục học tập</p>
         </div>
@@ -201,7 +203,7 @@ const Login = () => {
             </span>
           </p>
         </div>
-      </motion.div>
+      </Motion.div>
     </div>
   );
 };

--- a/src/Pages/teacher/test/testCreate.jsx
+++ b/src/Pages/teacher/test/testCreate.jsx
@@ -42,7 +42,9 @@ const TestCreate = () => {
                   key="parts"
                   size="large"
                   onClick={() =>
-                    navigate(`/teacher/testEdit/${createdTest.idTest}`)
+                    navigate(
+                      `/teacher/testManager/testEdit/${createdTest.idTest}`
+                    )
                   }
                   icon={<ArrowRightOutlined />}
                 >

--- a/src/Pages/teacher/test/testEdit.jsx
+++ b/src/Pages/teacher/test/testEdit.jsx
@@ -8,7 +8,8 @@ import { getDetailInTestAPI } from "@/services/apiDoTest";
 import CreateSpeaking from "@/components/test/teacher/Speaking/CreateSpeaking";
 
 const TestEdit = () => {
-  const { idTest } = useParams();
+  const { idTest, id } = useParams();
+  const resolvedTestId = idTest || id;
   const locationState = useLocation().state?.exam;
 
   const [exam, setExam] = useState(locationState || null);
@@ -17,11 +18,11 @@ const TestEdit = () => {
   // Fetch fresh data từ API khi component mount hoặc idTest thay đổi
   useEffect(() => {
     const fetchTestData = async () => {
-      if (!idTest) return;
+      if (!resolvedTestId) return;
 
       try {
         setLoading(true);
-        const res = await getDetailInTestAPI(idTest);
+        const res = await getDetailInTestAPI(resolvedTestId);
         if (res?.data) {
           setExam(res.data);
         } else {
@@ -39,7 +40,7 @@ const TestEdit = () => {
     };
 
     fetchTestData();
-  }, [idTest]);
+  }, [locationState, resolvedTestId]);
 
   // Callback để cập nhật exam state khi TestInfoEditor save thành công
   const handleExamUpdate = (updatedExam) => {
@@ -91,11 +92,6 @@ const TestEdit = () => {
             exam={exam}
             onExamUpdate={handleExamUpdate}
           />
-        );
-        return (
-          <p className="text-center py-12">
-            Loại đề không hợp lệ: {exam.testType}
-          </p>
         );
     }
   };

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -16,7 +16,16 @@ export const verifyOtpAPI = async (data) => {
 };
 
 export const resendOtpAPI = async (data) => {
-  const res = await API.post("/auth/resend-otp", data);
+  const rawType = data?.type;
+  const mappedType =
+    rawType === "RESET_PASSWORD"
+      ? "RESET_LINK"
+      : rawType || "OTP";
+
+  const res = await API.post("/auth/resend-otp", {
+    ...data,
+    type: mappedType,
+  });
   return res.data; // { message: "OTP resent" }
 };
 

--- a/src/services/apiDoTest.js
+++ b/src/services/apiDoTest.js
@@ -1,52 +1,140 @@
 import API from "./axios.custom";
+import {
+  mapLegacyAnswersToSubmitItems,
+  normalizeTestDataForLegacy,
+  normalizeTestResultDataForLegacy,
+} from "./contractAdapters";
+
+const pendingSubmitAnswers = new Map();
+
+const normalizeEnvelope = (responseData, normalizer) => {
+  if (!responseData || typeof responseData !== "object") return responseData;
+  if (responseData.data === undefined) return normalizer(responseData);
+  return {
+    ...responseData,
+    data: normalizer(responseData.data),
+  };
+};
+
+const withTopLevelAliases = (responseData) => {
+  const normalized = normalizeEnvelope(responseData, normalizeTestResultDataForLegacy);
+  if (!normalized?.data) return normalized;
+  return {
+    ...normalized,
+    band_score: normalized.data.band_score,
+    total_correct: normalized.data.total_correct,
+    total_questions: normalized.data.total_questions,
+  };
+};
 
 export const createManyAnswersAPI = async (idUser, idTestResult, data) => {
+  const legacyAnswers = Array.isArray(data?.answers) ? data.answers : [];
+  const mappedAnswers = mapLegacyAnswersToSubmitItems(legacyAnswers);
+
+  pendingSubmitAnswers.set(String(idTestResult), mappedAnswers);
+
+  if (mappedAnswers.length === 0) {
+    return {
+      message: "No answers to save",
+      data: { count: 0 },
+      status: 200,
+    };
+  }
+
   const res = await API.post(
-    `/user-answer/create-many-user-answers/${idUser}/${idTestResult}`,
-    data
+    `/user-answer/save-progress/${idUser}/${idTestResult}`,
+    { answers: mappedAnswers }
   );
+
   return res.data;
 };
+
 export const StartTestAPI = async (idUser, idTest, data) => {
   const res = await API.post(
     `/user-test-result/start-test/${idUser}/${idTest}`,
     data
   );
-  return res.data;
+
+  return withTopLevelAliases(res.data);
 };
 
-export const FinistTestAPI = async (idUser, idTestResult, data) => {
-  const res = await API.patch(
-    `/user-test-result/finish-test/${idUser}/${idTestResult}`,
-    data
+export const FinistTestAPI = async (idTestResult, idUser, data = {}) => {
+  const cachedAnswers = pendingSubmitAnswers.get(String(idTestResult)) || [];
+  const payloadAnswers = Array.isArray(data?.answers)
+    ? mapLegacyAnswersToSubmitItems(data.answers)
+    : cachedAnswers;
+
+  const payload = {
+    idTestResult,
+    answers: payloadAnswers,
+  };
+
+  if (typeof data?.duration === "number") {
+    payload.duration = data.duration;
+  }
+
+  const res = await API.post(
+    `/user-test-result/submit-reading-listening/${idUser}`,
+    payload
   );
-  return res.data;
+
+  pendingSubmitAnswers.delete(String(idTestResult));
+  return withTopLevelAliases(res.data);
 };
 
 export const FinishTestWritingAPI = async (idTestResult, idUser, data) => {
+  const writingSubmissions = Array.isArray(data?.writingSubmissions)
+    ? data.writingSubmissions.map((item) => ({
+        ...item,
+        submissionText: item?.submissionText || item?.submission_text || "",
+      }))
+    : [];
+
   const res = await API.patch(
     `/user-test-result/finish-test-writing/${idTestResult}/${idUser}`,
-    data
+    {
+      ...data,
+      writingSubmissions,
+    }
   );
-  return res.data;
+
+  const normalized = normalizeEnvelope(res.data, normalizeTestResultDataForLegacy);
+  if (Array.isArray(normalized?.data?.submissions)) {
+    normalized.data.submissions = normalized.data.submissions.map((submission) => ({
+      ...submission,
+      task_type: submission?.task_type || submission?.taskType,
+      submission_text: submission?.submission_text || submission?.submissionText,
+      band_score: submission?.band_score || submission?.score,
+    }));
+  }
+
+  return normalized;
 };
 
 export const getManyAnswersAPI = async (idTestResult, idUser) => {
+  const _unusedUserId = idUser;
   const res = await API.get(
-    `/user-answer/get-all-user-answers-by-idUser-and-idTestResult/${idTestResult}/${idUser}`
+    `/user-test-result/get-test-result-and-answers/${idTestResult}`
   );
-  return res.data;
+  const normalized = normalizeEnvelope(res.data, normalizeTestResultDataForLegacy);
+
+  return {
+    ...normalized,
+    data: normalized?.data?.userAnswer || [],
+  };
 };
 
 export const getDetailInTestAPI = async (idTest) => {
   const res = await API.get(`/test/get-detail-in-test/${idTest}`);
-  return res.data;
+
+  return normalizeEnvelope(res.data, normalizeTestDataForLegacy);
 };
 
 export const ResetTestAPI = async (idUser, idTestResult) => {
-  const res = await API.delete(
-    `/user-test-result/reset-test/${idUser}/${idTestResult}`
-  );
+  const targetTestResultId = idTestResult || idUser;
+  const res = await API.delete(`/user-test-result/reset-test/${targetTestResultId}`);
+
+  pendingSubmitAnswers.delete(String(targetTestResultId));
   return res.data;
 };
 
@@ -61,17 +149,20 @@ export const getTestResultByIdAPI = async (idTestResult) => {
   const res = await API.get(
     `/user-test-result/get-test-result/${idTestResult}`
   );
-  return res.data;
+
+  return withTopLevelAliases(res.data);
 };
 
 export const getTestAnswerAPI = async (idTest) => {
   const res = await API.get(`/test/get-answers-in-test/${idTest}`);
-  return res.data;
+
+  return normalizeEnvelope(res.data, normalizeTestDataForLegacy);
 };
 
 export const getTestResultAndAnswersAPI = async (idTestResult) => {
   const res = await API.get(
     `/user-test-result/get-test-result-and-answers/${idTestResult}`
   );
-  return res.data;
+
+  return withTopLevelAliases(res.data);
 };

--- a/src/services/apiForum.js
+++ b/src/services/apiForum.js
@@ -1,4 +1,28 @@
 import API from "./axios.custom";
+import Cookies from "js-cookie";
+
+const resolveCurrentUserId = (idUser) => {
+  if (idUser) return idUser;
+
+  try {
+    const rawUser = Cookies.get("user");
+    if (!rawUser) return null;
+    const parsed = JSON.parse(rawUser);
+    return parsed?.idUser || null;
+  } catch {
+    return null;
+  }
+};
+
+const buildDeleteConfig = (idUser) => {
+  const resolvedUserId = resolveCurrentUserId(idUser);
+  if (!resolvedUserId) return undefined;
+  return {
+    data: {
+      idUser: resolvedUserId,
+    },
+  };
+};
 
 //Get
 export const getAllThreadAPI = async () => {
@@ -99,21 +123,26 @@ export const updateCommentAPI = async (idForumComment, data) => {
 };
 
 //delete
-export const deleteThreadAPI = async (idForumThreads) => {
+export const deleteThreadAPI = async (idForumThreads, idUser) => {
   const res = await API.delete(
-    `/forum-threads/delete-forum-thread/${idForumThreads}`
+    `/forum-threads/delete-forum-thread/${idForumThreads}`,
+    buildDeleteConfig(idUser)
   );
   return res.data;
 };
 
-export const deletePostAPI = async (idForumPost) => {
-  const res = await API.delete(`/forum-post/delete-forum-post/${idForumPost}`);
+export const deletePostAPI = async (idForumPost, idUser) => {
+  const res = await API.delete(
+    `/forum-post/delete-forum-post/${idForumPost}`,
+    buildDeleteConfig(idUser)
+  );
   return res.data;
 };
 
-export const deleteCommentAPI = async (idForumComment) => {
+export const deleteCommentAPI = async (idForumComment, idUser) => {
   const res = await API.delete(
-    `/forum-comment/delete-forum-comment/${idForumComment}`
+    `/forum-comment/delete-forum-comment/${idForumComment}`,
+    buildDeleteConfig(idUser)
   );
   return res.data;
 };

--- a/src/services/apiSpeaking.js
+++ b/src/services/apiSpeaking.js
@@ -1,5 +1,26 @@
 import API from "./axios.custom";
 
+const normalizeEnvelope = (responseData) => {
+  if (!responseData || typeof responseData !== "object") return responseData;
+
+  if (responseData?.data?.idSpeakingTask || Array.isArray(responseData?.data)) {
+    return {
+      ...responseData,
+      data: Array.isArray(responseData.data)
+        ? responseData.data.map((task) => ({
+            ...task,
+            part: task?.part || task?.partType,
+          }))
+        : {
+            ...responseData.data,
+            part: responseData?.data?.part || responseData?.data?.partType,
+          },
+    };
+  }
+
+  return responseData;
+};
+
 // =============================================================================
 // SPEAKING TASK APIS (FORM DATA)
 // =============================================================================
@@ -20,14 +41,17 @@ export const updateSpeakingTask = async (idSpeakingTask, data) => {
 };
 
 export const getAllSpeakingTasks = async (idTest) => {
-  const res = await API.get(`/speaking-task/find-all-speaking-tasks/${idTest}`);
-  return res.data;
+  const res = await API.get(
+    `/speaking-task/find-all-speaking-tasks-in-test/${idTest}`
+  );
+  return normalizeEnvelope(res.data);
 };
 
 export const getSpeakingTask = async (idSpeakingTask) => {
   const res = await API.get(
     `/speaking-task/find-speaking-task/${idSpeakingTask}`
   );
+  return normalizeEnvelope(res.data);
 };
 
 export const deleteSpeakingTask = async (idSpeakingTask) => {

--- a/src/services/apiTest.js
+++ b/src/services/apiTest.js
@@ -1,5 +1,66 @@
 import API from "./axios.custom";
-import axios from "axios";
+import {
+  encodeInstructionsWithQuantity,
+  mapBackendQuestionToLegacyQuestion,
+  mapLegacyQuestionsPayloadToBackend,
+  mapLegacyGroupTypeToBackendQuestionType,
+  normalizeGroupForLegacy,
+  normalizePartForLegacy,
+} from "./contractAdapters";
+
+const normalizeEnvelope = (responseData, normalizer) => {
+  if (!responseData || typeof responseData !== "object") return responseData;
+  if (responseData.data === undefined) return normalizer(responseData);
+  return {
+    ...responseData,
+    data: normalizer(responseData.data),
+  };
+};
+
+const buildQuestionGroupFormData = (data = {}) => {
+  const formData = new FormData();
+
+  formData.append("idPart", data.idPart);
+  formData.append(
+    "questionType",
+    mapLegacyGroupTypeToBackendQuestionType(
+      data.typeQuestion || data.questionType
+    )
+  );
+  formData.append("title", data.title || "");
+
+  const encodedInstructions = encodeInstructionsWithQuantity(
+    data.instructions || data.instruction || "",
+    data.quantity
+  );
+  if (encodedInstructions) {
+    formData.append("instructions", encodedInstructions);
+  }
+
+  if (data.order !== undefined && data.order !== null) {
+    formData.append("order", String(data.order));
+  }
+
+  const imageFile = data.imageUrl || data.img || data.image;
+  if (imageFile !== undefined && imageFile !== null) {
+    formData.append("imageUrl", imageFile);
+  }
+
+  return formData;
+};
+
+const normalizeQuestionGroupResponseAsLegacyArray = (responseData) => {
+  const normalized = normalizeGroupForLegacy(responseData?.data || responseData);
+  return {
+    ...(responseData || {}),
+    data: normalized ? [normalized] : [],
+  };
+};
+
+const stripQuestionIdFromCreatePayload = (question) => {
+  const { idQuestion: _idQuestion, ...rest } = question;
+  return rest;
+};
 
 export const getAPITest = async () => {
   const res = await API.get("/test/get-all-test");
@@ -63,29 +124,27 @@ export const createPassageAPI = async (formData) => {
 };
 
 export const createGroupOfQuestionsAPI = async (data) => {
-  const formData = new FormData();
+  const formData = buildQuestionGroupFormData(data);
+  const res = await API.post("/question-group/create-question-group", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
 
-  // Thêm các fields vào FormData
-  for (const key in data) {
-    if (data[key] != null) {
-      formData.append(key, data[key]);
-    }
-  }
-
-  const res = await API.post(
-    "/group-of-questions/create-group-question",
-    formData,
-    {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
-    }
-  );
-  return res.data;
+  return normalizeEnvelope(res.data, normalizeGroupForLegacy);
 };
 
 export const createQuestion = async (data) => {
-  const res = await API.post("/question/create-question", data);
+  const isLegacyPayload =
+    !!data?.idGroupOfQuestions || Array.isArray(data?.answers);
+
+  let payload = data;
+  if (isLegacyPayload) {
+    const [mappedQuestion] = await mapLegacyQuestionsPayloadToBackend(API, [data]);
+    payload = stripQuestionIdFromCreatePayload(mappedQuestion);
+  }
+
+  const res = await API.post("/question/create-question", payload);
   return res.data;
 };
 
@@ -113,7 +172,18 @@ export const createUserTestResult = async (idUser, idTest, data) => {
 };
 
 export const createManyQuestion = async (data) => {
-  const res = await API.post(`/question/create-many-questions`, data);
+  const sourceQuestions = Array.isArray(data?.questions) ? data.questions : [];
+  const mappedQuestions = await mapLegacyQuestionsPayloadToBackend(
+    API,
+    sourceQuestions
+  );
+  const payload = {
+    questions: mappedQuestions.map((question) =>
+      stripQuestionIdFromCreatePayload(question)
+    ),
+  };
+
+  const res = await API.post(`/question/create-many-questions`, payload);
   return res.data;
 };
 
@@ -125,7 +195,7 @@ export const deletePartAPI = async (idPart) => {
 
 export const deleteGroupOfQuestionsAPI = async (idGroupOfQuestions) => {
   const res = await API.delete(
-    `/group-of-questions/delete-group-of-questions/${idGroupOfQuestions}`
+    `/question-group/delete-question-group/${idGroupOfQuestions}`
   );
   return res.data;
 };
@@ -138,18 +208,32 @@ export const getAllPartByIdAPI = async (idTest) => {
 
 export const getPartByIdAPI = async (idPart) => {
   const res = await API.get(`/part/get-one/${idPart}`);
-  return res.data;
+
+  return normalizeEnvelope(res.data, (parts) =>
+    (Array.isArray(parts) ? parts : []).map((part) => normalizePartForLegacy(part))
+  );
 };
 export const getQuestionsByIdGroupAPI = async (idGroupOfQuestions) => {
-  const res = await API.get(
-    `/group-of-questions/get-by-id/${idGroupOfQuestions}`
-  );
-  return res.data;
+  const res = await API.get(`/question-group/get-by-id/${idGroupOfQuestions}`);
+  return normalizeQuestionGroupResponseAsLegacyArray(res.data);
 };
 
 export const getAnswersByIdQuestionAPI = async (idQuestion) => {
-  const res = await API.get(`/answer/get-by-id-question/${idQuestion}`);
-  return res.data;
+  const res = await API.get(`/question/find-by-id/${idQuestion}`);
+  const question = res?.data?.data;
+
+  if (Array.isArray(question?.answers) && question.answers.length > 0) {
+    return {
+      ...res.data,
+      data: question.answers,
+    };
+  }
+
+  const mapped = mapBackendQuestionToLegacyQuestion(question || {});
+  return {
+    ...res.data,
+    data: mapped?.answers || [],
+  };
 };
 
 //patch
@@ -164,11 +248,18 @@ export const updatePassageAPI = async (idPassage, data) => {
 };
 
 export const updateGroupOfQuestionsAPI = async (idGroupOfQuestions, data) => {
+  const formData = buildQuestionGroupFormData(data);
   const res = await API.patch(
-    `/group-of-questions/update-group-of-questions/${idGroupOfQuestions}`,
-    data
+    `/question-group/update-question-group/${idGroupOfQuestions}`,
+    formData,
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
   );
-  return res.data;
+
+  return normalizeEnvelope(res.data, normalizeGroupForLegacy);
 };
 
 export const updateAnswerAPI = async (idAnswer, data) => {
@@ -176,11 +267,62 @@ export const updateAnswerAPI = async (idAnswer, data) => {
   return res.data;
 };
 export const updateQuestionAPI = async (idQuestion, data) => {
-  const res = await API.patch(`/question/update-question/${idQuestion}`, data);
+  const isLegacyPayload =
+    !!data?.idGroupOfQuestions || Array.isArray(data?.answers);
+
+  let payload = data;
+  if (isLegacyPayload) {
+    const [mappedQuestion] = await mapLegacyQuestionsPayloadToBackend(API, [
+      {
+        ...data,
+        idQuestion,
+      },
+    ]);
+    payload = stripQuestionIdFromCreatePayload(mappedQuestion);
+  }
+
+  const res = await API.patch(`/question/update-question/${idQuestion}`, payload);
   return res.data;
 };
 
 export const updateManyQuestionAPI = async (data) => {
-  const res = await API.patch(`/question/update-many-questions`, data);
-  return res.data;
+  const sourceQuestions = Array.isArray(data?.questions) ? data.questions : [];
+  const mappedQuestions = await mapLegacyQuestionsPayloadToBackend(
+    API,
+    sourceQuestions
+  );
+
+  const toUpdate = mappedQuestions.filter((question) => !!question.idQuestion);
+  const toCreate = mappedQuestions
+    .filter((question) => !question.idQuestion)
+    .map((question) => stripQuestionIdFromCreatePayload(question));
+
+  const updatedRecords = [];
+
+  if (toUpdate.length > 0) {
+    const updateResponses = await Promise.all(
+      toUpdate.map(async (question) => {
+        const { idQuestion, ...payload } = question;
+        const res = await API.patch(`/question/update-question/${idQuestion}`, payload);
+        return res?.data?.data || res?.data || null;
+      })
+    );
+    updatedRecords.push(...updateResponses.filter(Boolean));
+  }
+
+  if (toCreate.length > 0) {
+    const createRes = await API.post(`/question/create-many-questions`, {
+      questions: toCreate,
+    });
+    const created = Array.isArray(createRes?.data?.data)
+      ? createRes.data.data
+      : [];
+    updatedRecords.push(...created);
+  }
+
+  return {
+    message: "Questions updated successfully",
+    data: updatedRecords,
+    status: 200,
+  };
 };

--- a/src/services/apiUser.js
+++ b/src/services/apiUser.js
@@ -5,7 +5,7 @@ export const userProfileAPI = async (id) => {
 };
 
 export const getAllUserAPI = async (params = {}) => {
-  const res = await API.get(`/users/get-all`, params);
+  const res = await API.get(`/users/get-all`, { params });
   return res.data;
 };
 
@@ -24,7 +24,7 @@ export const updateUserAPI = async (id, data) => {
 };
 
 export const deleteUserAPI = async (id) => {
-  const res = await API.delete(`/users/${id}`);
+  const res = await API.delete(`/users/delete-user/${id}`);
   return res.data;
 };
 

--- a/src/services/apiVocab.js
+++ b/src/services/apiVocab.js
@@ -41,7 +41,7 @@ export const updateVocabAPI = async (idVocab, payload) => {
 };
 
 export const addVocabToTopic = async (data) => {
-  const res = await API.post(`/vocabulary/add-vocabulary-to-topic`);
+  const res = await API.post(`/vocabulary/add-vocabulary-to-topic`, data);
   return res.data;
 };
 

--- a/src/services/apiWriting.js
+++ b/src/services/apiWriting.js
@@ -1,5 +1,57 @@
 import API from "./axios.custom";
 
+const normalizeWritingTask = (task) => ({
+  ...task,
+  task_type: task?.task_type || task?.taskType,
+  taskType: task?.taskType || task?.task_type,
+  time_limit: task?.time_limit || task?.timeLimit,
+  timeLimit: task?.timeLimit || task?.time_limit,
+});
+
+const normalizeWritingSubmission = (submission) => ({
+  ...submission,
+  submission_text: submission?.submission_text || submission?.submissionText,
+  submissionText: submission?.submissionText || submission?.submission_text,
+  writingTask: submission?.writingTask
+    ? normalizeWritingTask(submission.writingTask)
+    : submission?.writingTask,
+});
+
+const normalizeEnvelope = (responseData) => {
+  if (!responseData || typeof responseData !== "object") return responseData;
+  if (responseData.data === undefined) return responseData;
+
+  const data = responseData.data;
+
+  if (Array.isArray(data)) {
+    const looksLikeTasks = data.some((item) => item?.idWritingTask || item?.taskType);
+    const mapped = looksLikeTasks
+      ? data.map((item) => normalizeWritingTask(item))
+      : data.map((item) => normalizeWritingSubmission(item));
+
+    return {
+      ...responseData,
+      data: mapped,
+    };
+  }
+
+  if (data?.idWritingTask || data?.taskType) {
+    return {
+      ...responseData,
+      data: normalizeWritingTask(data),
+    };
+  }
+
+  if (data?.idWritingSubmission || data?.submissionText || data?.submission_text) {
+    return {
+      ...responseData,
+      data: normalizeWritingSubmission(data),
+    };
+  }
+
+  return responseData;
+};
+
 //post
 export const createWritingTaskAPI = async (formdata) => {
   const res = await API.post("/writing-task/create-writing-task", formdata, {
@@ -10,37 +62,47 @@ export const createWritingTaskAPI = async (formdata) => {
   return res.data; // { id, title, description, ... }
 };
 
-export const createWritingSubmissionAPI = async (data) => {
+export const createWritingSubmissionAPI = async (data, idTestResult) => {
+  const targetTestResult = idTestResult || data?.idTestResult;
+  if (!targetTestResult) {
+    throw new Error("idTestResult is required for createWritingSubmissionAPI");
+  }
+
+  const normalizedData = {
+    ...data,
+    submissionText: data?.submissionText || data?.submission_text,
+  };
+
   const res = await API.post(
-    "/user-writing-submission/create-writing-submission",
-    data
+    `/user-writing-submission/create-writing-submission/${targetTestResult}`,
+    normalizedData
   );
-  return res.data; // { id, taskId, userId, content, ... }
+  return normalizeEnvelope(res.data); // { id, taskId, userId, content, ... }
 };
 
 //get
 export const getAllWritingTasksAPI = async (idTest) => {
   const res = await API.get(`/writing-task/get-all-writing-task/${idTest}`);
-  return res.data; // [ { id, title, description, ... }, ... ]
+  return normalizeEnvelope(res.data); // [ { id, title, description, ... }, ... ]
 };
 
 export const getWritingTaskAPI = async (idWritingTask) => {
   const res = await API.get(`/writing-task/get-writing-task/${idWritingTask}`);
-  return res.data; // { id, title, description, ... }
+  return normalizeEnvelope(res.data); // { id, title, description, ... }
 };
 
 export const getWritingSubmissionsByTaskAPI = async (idUser) => {
   const res = await API.get(
     `/user-writing-submission/get-all-writing-submission-by-id-user/${idUser}`
   );
-  return res.data;
+  return normalizeEnvelope(res.data);
 };
 
 export const getWritingSubmissionAPI = async (idWritingSubmission) => {
   const res = await API.get(
     `/user-writing-submission/get-writing-submission/${idWritingSubmission}`
   );
-  return res.data;
+  return normalizeEnvelope(res.data);
 };
 //patch
 export const updateWritingTaskAPI = async (idWritingTask, formdata) => {
@@ -53,7 +115,7 @@ export const updateWritingTaskAPI = async (idWritingTask, formdata) => {
       },
     }
   );
-  return res.data; // { id, title, description, ... }
+  return normalizeEnvelope(res.data); // { id, title, description, ... }
 };
 //delete
 

--- a/src/services/contractAdapters.js
+++ b/src/services/contractAdapters.js
@@ -1,0 +1,869 @@
+const LEGACY_GROUP_TO_BACKEND_TYPE = {
+  MCQ: "MULTIPLE_CHOICE",
+  TFNG: "TRUE_FALSE_NOT_GIVEN",
+  YES_NO_NOTGIVEN: "YES_NO_NOT_GIVEN",
+  MATCHING: "MATCHING_FEATURES",
+  FILL_BLANK: "SENTENCE_COMPLETION",
+  LABELING: "DIAGRAM_LABELING",
+  SHORT_ANSWER: "SHORT_ANSWER",
+  OTHER: "SHORT_ANSWER",
+};
+
+const BACKEND_TO_LEGACY_GROUP_TYPE = {
+  MULTIPLE_CHOICE: "MCQ",
+  TRUE_FALSE_NOT_GIVEN: "TFNG",
+  YES_NO_NOT_GIVEN: "YES_NO_NOTGIVEN",
+  MATCHING_HEADING: "MATCHING",
+  MATCHING_INFORMATION: "MATCHING",
+  MATCHING_FEATURES: "MATCHING",
+  MATCHING_SENTENCE_ENDINGS: "MATCHING",
+  SENTENCE_COMPLETION: "FILL_BLANK",
+  SUMMARY_COMPLETION: "FILL_BLANK",
+  NOTE_COMPLETION: "FILL_BLANK",
+  TABLE_COMPLETION: "FILL_BLANK",
+  FLOW_CHART_COMPLETION: "FILL_BLANK",
+  DIAGRAM_LABELING: "LABELING",
+  SHORT_ANSWER: "SHORT_ANSWER",
+};
+
+const NOT_GIVEN_VARIANTS = ["NOT GIVEN", "NOT_GIVEN", "NOTGIVEN"];
+const EMPTY_IMAGE_FALLBACK = "https://example.com/placeholder-diagram.png";
+const QTY_MARKER_REGEX = /\[\[QTY:(\d+)\]\]/i;
+
+const toArray = (value) => (Array.isArray(value) ? value : []);
+
+const toStringSafe = (value, fallback = "") => {
+  if (value === null || value === undefined) return fallback;
+  return String(value);
+};
+
+const stripHtml = (html) =>
+  toStringSafe(html)
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const normalizeNotGiven = (value) => {
+  const raw = toStringSafe(value).trim().toUpperCase();
+  if (NOT_GIVEN_VARIANTS.includes(raw)) return "NOT_GIVEN";
+  return raw;
+};
+
+const denormalizeNotGiven = (value) => {
+  if (normalizeNotGiven(value) === "NOT_GIVEN") return "NOT GIVEN";
+  return toStringSafe(value).trim().toUpperCase();
+};
+
+const keyToIndex = (matchingKey) => {
+  if (matchingKey === null || matchingKey === undefined) return -1;
+  const raw = toStringSafe(matchingKey).trim();
+  if (!raw) return -1;
+  if (/^\d+$/.test(raw)) return Number(raw);
+  const upper = raw.toUpperCase();
+  const code = upper.charCodeAt(0);
+  if (code >= 65 && code <= 90) return code - 65;
+  return -1;
+};
+
+const indexToKey = (index) => {
+  if (typeof index !== "number" || Number.isNaN(index) || index < 0) {
+    return null;
+  }
+  return String.fromCharCode(65 + index);
+};
+
+const uniqueBy = (items, keyGetter) => {
+  const seen = new Set();
+  const result = [];
+  items.forEach((item) => {
+    const key = keyGetter(item);
+    if (seen.has(key)) return;
+    seen.add(key);
+    result.push(item);
+  });
+  return result;
+};
+
+const parseQuantityFromTitle = (title) => {
+  const text = toStringSafe(title);
+  const match = text.match(/questions?\s*(\d+)\s*[-–]\s*(\d+)/i);
+  if (!match) return null;
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return null;
+  return end - start + 1;
+};
+
+export const mapLegacyGroupTypeToBackendQuestionType = (legacyType) => {
+  return LEGACY_GROUP_TO_BACKEND_TYPE[toStringSafe(legacyType).trim()] || "SHORT_ANSWER";
+};
+
+export const mapBackendQuestionTypeToLegacyGroupType = (backendType) => {
+  return BACKEND_TO_LEGACY_GROUP_TYPE[toStringSafe(backendType).trim()] || "OTHER";
+};
+
+export const encodeInstructionsWithQuantity = (instructions, quantity) => {
+  const cleaned = toStringSafe(instructions).replace(QTY_MARKER_REGEX, "").trim();
+  const qty = Number(quantity);
+  if (!Number.isFinite(qty) || qty <= 0) return cleaned;
+  if (!cleaned) return `[[QTY:${qty}]]`;
+  return `${cleaned}\n[[QTY:${qty}]]`;
+};
+
+export const decodeInstructionsAndQuantity = (instructions, fallbackQuantity) => {
+  const raw = toStringSafe(instructions);
+  const match = raw.match(QTY_MARKER_REGEX);
+  const parsedQuantity = match ? Number(match[1]) : null;
+  const cleanedInstructions = raw.replace(QTY_MARKER_REGEX, "").replace(/\n{3,}/g, "\n\n").trim();
+
+  if (Number.isFinite(parsedQuantity) && parsedQuantity > 0) {
+    return { instructions: cleanedInstructions, quantity: parsedQuantity };
+  }
+
+  const fallback = Number(fallbackQuantity);
+  return {
+    instructions: cleanedInstructions,
+    quantity: Number.isFinite(fallback) && fallback > 0 ? fallback : null,
+  };
+};
+
+const mapMetadataToLegacyAnswers = (metadata, backendQuestionType) => {
+  const type = toStringSafe(metadata?.type || backendQuestionType).trim();
+
+  if (type === "MULTIPLE_CHOICE") {
+    const options = toArray(metadata?.options);
+    const correct = new Set(toArray(metadata?.correctOptionIndexes));
+    const answers = options.map((opt, index) => ({
+      answer_id: `${toStringSafe(opt?.label || index)}-${index}`,
+      answer_text: toStringSafe(opt?.text),
+      matching_key: toStringSafe(opt?.label || indexToKey(index) || index),
+      matching_value: correct.has(index) ? "CORRECT" : "INCORRECT",
+    }));
+
+    return {
+      answers,
+      correct_answers: answers.filter((ans) => ans.matching_value === "CORRECT"),
+    };
+  }
+
+  if (type === "TRUE_FALSE_NOT_GIVEN") {
+    const answerText = denormalizeNotGiven(metadata?.correctAnswer);
+    const answer = {
+      answer_id: "tfng",
+      answer_text: answerText,
+      matching_key: "TFNG",
+      matching_value: answerText,
+    };
+    return { answers: [answer], correct_answers: [answer] };
+  }
+
+  if (type === "YES_NO_NOT_GIVEN") {
+    const answerText = denormalizeNotGiven(metadata?.correctAnswer);
+    const answer = {
+      answer_id: "ynng",
+      answer_text: answerText,
+      matching_key: "YES_NO_NOT_GIVEN",
+      matching_value: answerText,
+    };
+    return { answers: [answer], correct_answers: [answer] };
+  }
+
+  if (type.startsWith("MATCHING_")) {
+    let options = [];
+    let correctKey = null;
+
+    if (type === "MATCHING_HEADING") {
+      options = toArray(metadata?.headings).map((item, index) => ({
+        key: toStringSafe(item?.label || indexToKey(index) || index),
+        text: toStringSafe(item?.text),
+      }));
+      const idx = Number(metadata?.correctHeadingIndex);
+      correctKey = Number.isFinite(idx) ? toStringSafe(options[idx]?.key) : null;
+    } else if (type === "MATCHING_INFORMATION") {
+      options = toArray(metadata?.paragraphLabels).map((label) => ({
+        key: toStringSafe(label),
+        text: toStringSafe(label),
+      }));
+      correctKey = toStringSafe(metadata?.correctParagraph);
+    } else if (type === "MATCHING_FEATURES") {
+      options = toArray(metadata?.features).map((item, index) => ({
+        key: toStringSafe(item?.label || indexToKey(index) || index),
+        text: toStringSafe(item?.text),
+      }));
+      correctKey = toStringSafe(metadata?.correctFeatureLabel);
+    } else {
+      options = toArray(metadata?.endings).map((item, index) => ({
+        key: toStringSafe(item?.label || indexToKey(index) || index),
+        text: toStringSafe(item?.text),
+      }));
+      correctKey = toStringSafe(metadata?.correctEndingLabel);
+    }
+
+    const answers = options.map((opt) => ({
+      answer_id: `${opt.key}`,
+      answer_text: opt.text,
+      matching_key: opt.key,
+      matching_value: opt.key === correctKey ? "CORRECT" : null,
+    }));
+
+    return {
+      answers,
+      correct_answers: answers.filter((ans) => ans.matching_value === "CORRECT"),
+    };
+  }
+
+  if (type === "DIAGRAM_LABELING") {
+    const wordBank = toArray(metadata?.wordBank);
+    const correctSet = new Set(toArray(metadata?.correctAnswers).map((ans) => ans.toLowerCase().trim()));
+
+    const answers = wordBank.map((item, index) => {
+      const key = indexToKey(index) || toStringSafe(item?.id || index + 1);
+      const text = toStringSafe(item?.text || item?.id);
+      return {
+        answer_id: `${key}`,
+        answer_text: text,
+        matching_key: key,
+        matching_value: correctSet.has(text.toLowerCase().trim()) ? "CORRECT" : null,
+      };
+    });
+
+    const fallbackText = toArray(metadata?.correctAnswers)[0];
+    if (answers.length === 0 && fallbackText) {
+      const answer = {
+        answer_id: "diagram",
+        answer_text: toStringSafe(fallbackText),
+        matching_key: "A",
+        matching_value: "CORRECT",
+      };
+      return { answers: [answer], correct_answers: [answer] };
+    }
+
+    return {
+      answers,
+      correct_answers: answers.filter((ans) => ans.matching_value === "CORRECT"),
+    };
+  }
+
+  const correctAnswers = toArray(metadata?.correctAnswers)
+    .map((item) => toStringSafe(item).trim())
+    .filter(Boolean);
+
+  const wordBank = toArray(metadata?.wordBank);
+  if (wordBank.length > 0) {
+    const lowerCorrect = new Set(correctAnswers.map((ans) => ans.toLowerCase()));
+    const answers = wordBank.map((item, index) => {
+      const key = indexToKey(index) || toStringSafe(item?.id || index + 1);
+      const text = toStringSafe(item?.text || item?.id);
+      return {
+        answer_id: `${key}`,
+        answer_text: text,
+        matching_key: key,
+        matching_value: lowerCorrect.has(text.toLowerCase()) ? "CORRECT" : null,
+      };
+    });
+
+    return {
+      answers,
+      correct_answers: answers.filter((ans) => ans.matching_value === "CORRECT"),
+    };
+  }
+
+  const fallbackText = correctAnswers[0] || "N/A";
+  const singleAnswer = {
+    answer_id: "text",
+    answer_text: fallbackText,
+    matching_key: null,
+    matching_value: null,
+  };
+
+  return {
+    answers: [singleAnswer],
+    correct_answers: [singleAnswer],
+  };
+};
+
+export const mapBackendQuestionToLegacyQuestion = (question, groupContext = {}) => {
+  const backendQuestionType =
+    question?.questionType || groupContext?.questionType || mapLegacyGroupTypeToBackendQuestionType(groupContext?.typeQuestion);
+
+  const metadata = question?.metadata || {};
+  const mapped = mapMetadataToLegacyAnswers(metadata, backendQuestionType);
+
+  const questionText =
+    question?.content ||
+    metadata?.statement ||
+    metadata?.sentenceWithBlank ||
+    metadata?.fullParagraph ||
+    metadata?.fullFlowText ||
+    metadata?.fullNoteText ||
+    "";
+
+  return {
+    ...question,
+    idQuestion: question?.idQuestion,
+    numberQuestion: question?.questionNumber || question?.numberQuestion,
+    content: questionText,
+    questionType: backendQuestionType,
+    answers: mapped.answers,
+    correct_answers: mapped.correct_answers,
+  };
+};
+
+export const normalizeGroupForLegacy = (group) => {
+  const groupId = group?.idGroupOfQuestions || group?.idQuestionGroup;
+  const backendQuestionType =
+    group?.questionType || mapLegacyGroupTypeToBackendQuestionType(group?.typeQuestion);
+
+  const sourceQuestions = toArray(group?.question || group?.questions);
+  const questions = sourceQuestions.map((question) =>
+    mapBackendQuestionToLegacyQuestion(question, {
+      questionType: backendQuestionType,
+      typeQuestion: group?.typeQuestion,
+    })
+  );
+
+  const decoded = decodeInstructionsAndQuantity(group?.instructions || group?.instruction, group?.quantity);
+  const titleQuantity = parseQuantityFromTitle(group?.title);
+  const quantity =
+    decoded.quantity ||
+    group?.quantity ||
+    questions.length ||
+    titleQuantity ||
+    1;
+
+  const legacyType = group?.typeQuestion || mapBackendQuestionTypeToLegacyGroupType(backendQuestionType);
+
+  return {
+    ...group,
+    idGroupOfQuestions: groupId,
+    idQuestionGroup: groupId,
+    typeQuestion: legacyType,
+    questionType: backendQuestionType,
+    quantity,
+    img: group?.img || group?.imageUrl || null,
+    imageUrl: group?.imageUrl || group?.img || null,
+    instruction: decoded.instructions,
+    instructions: decoded.instructions,
+    question: questions,
+    questions,
+  };
+};
+
+export const normalizePartForLegacy = (part) => {
+  const sourceGroups = toArray(part?.groupOfQuestions || part?.questionGroups);
+  const groups = sourceGroups.map((group) => normalizeGroupForLegacy(group));
+
+  return {
+    ...part,
+    groupOfQuestions: groups,
+    questionGroups: groups,
+  };
+};
+
+const normalizeWritingTask = (task) => ({
+  ...task,
+  task_type: task?.task_type || task?.taskType,
+  taskType: task?.taskType || task?.task_type,
+  time_limit: task?.time_limit || task?.timeLimit,
+  timeLimit: task?.timeLimit || task?.time_limit,
+});
+
+const normalizeWritingSubmission = (submission) => ({
+  ...submission,
+  submission_text: submission?.submission_text || submission?.submissionText,
+  submissionText: submission?.submissionText || submission?.submission_text,
+  band_score: submission?.band_score || submission?.score || submission?.aiOverallScore,
+  writingTask: submission?.writingTask
+    ? normalizeWritingTask(submission.writingTask)
+    : submission?.writingTask,
+});
+
+const normalizeSpeakingSubmission = (submission) => ({
+  ...submission,
+  band_score: submission?.band_score || submission?.overallScore || submission?.aiOverallScore,
+});
+
+export const normalizeTestDataForLegacy = (testData) => {
+  if (!testData || typeof testData !== "object") return testData;
+
+  const parts = toArray(testData?.parts).map((part) => normalizePartForLegacy(part));
+  const writingTasks = toArray(testData?.writingTasks).map((task) => normalizeWritingTask(task));
+
+  return {
+    ...testData,
+    parts,
+    writingTasks,
+    speakingTasks: toArray(testData?.speakingTasks),
+  };
+};
+
+const payloadToLegacyUserAnswer = (userAnswer) => {
+  const payload = userAnswer?.answerPayload || {};
+  const answerType = toStringSafe(userAnswer?.answerType);
+  const legacyType = mapBackendQuestionTypeToLegacyGroupType(answerType);
+
+  let answerText = payload?.answerText || payload?.answer || "";
+  let matchingKey = null;
+  let matchingValue = null;
+
+  if (answerType === "MULTIPLE_CHOICE") {
+    const index = toArray(payload?.selectedIndexes)[0];
+    matchingKey = indexToKey(index);
+    answerText = answerText || matchingKey || "";
+  } else if (answerType === "TRUE_FALSE_NOT_GIVEN" || answerType === "YES_NO_NOT_GIVEN") {
+    matchingValue = denormalizeNotGiven(payload?.answer || answerText);
+    answerText = matchingValue;
+  } else if (answerType.startsWith("MATCHING_")) {
+    matchingKey = toStringSafe(payload?.selectedLabel || answerText);
+    answerText = answerText || matchingKey;
+  } else if (answerType === "DIAGRAM_LABELING") {
+    answerText = payload?.answerText || answerText;
+  } else {
+    answerText = payload?.answerText || answerText;
+  }
+
+  return {
+    ...userAnswer,
+    answerText,
+    userAnswerType: legacyType,
+    matching_key: matchingKey,
+    matching_value: matchingValue,
+  };
+};
+
+export const normalizeTestResultDataForLegacy = (rawData) => {
+  if (!rawData || typeof rawData !== "object") return rawData;
+
+  const test = rawData?.test ? normalizeTestDataForLegacy(rawData.test) : rawData?.test;
+  const userAnswersSource = toArray(rawData?.userAnswers || rawData?.userAnswer);
+  const userAnswers = userAnswersSource.map((item) =>
+    item?.answerPayload ? payloadToLegacyUserAnswer(item) : item
+  );
+
+  const writingSubmissions = toArray(rawData?.writingSubmissions || rawData?.writingSubmission).map((item) =>
+    normalizeWritingSubmission(item)
+  );
+  const speakingSubmissions = toArray(rawData?.speakingSubmissions || rawData?.speakingSubmission).map((item) =>
+    normalizeSpeakingSubmission(item)
+  );
+
+  const bandScore = rawData?.bandScore ?? rawData?.band_score ?? rawData?.data?.bandScore ?? rawData?.data?.band_score;
+  const totalCorrect = rawData?.totalCorrect ?? rawData?.total_correct;
+  const totalQuestions = rawData?.totalQuestions ?? rawData?.total_questions;
+
+  return {
+    ...rawData,
+    test,
+    userAnswers,
+    userAnswer: userAnswers,
+    writingSubmissions,
+    writingSubmission: writingSubmissions,
+    speakingSubmissions,
+    speakingSubmission: speakingSubmissions,
+    bandScore,
+    band_score: bandScore,
+    totalCorrect,
+    total_correct: totalCorrect,
+    totalQuestions,
+    total_questions: totalQuestions,
+  };
+};
+
+const inferLegacyTypeFromQuestion = (question, groupContext) => {
+  if (groupContext?.typeQuestion) return groupContext.typeQuestion;
+  if (groupContext?.questionType) {
+    return mapBackendQuestionTypeToLegacyGroupType(groupContext.questionType);
+  }
+  if (question?.typeQuestion) return question.typeQuestion;
+
+  const answers = toArray(question?.answers);
+  if (answers.length > 1 && answers.some((ans) => ans?.matching_key)) return "MATCHING";
+  if (answers.length > 1) return "MCQ";
+  return "SHORT_ANSWER";
+};
+
+const ensureCorrectAnswers = (values, fallback = "N/A") => {
+  const normalized = toArray(values)
+    .map((item) => toStringSafe(item).trim())
+    .filter(Boolean);
+
+  if (normalized.length > 0) return normalized;
+  return [fallback];
+};
+
+const buildWordBankFromLegacyAnswers = (answers) => {
+  const withKey = toArray(answers).filter((item) => item?.matching_key);
+  const unique = uniqueBy(withKey, (item) => toStringSafe(item.matching_key));
+
+  return unique.map((item, index) => ({
+    id: toStringSafe(item.matching_key || indexToKey(index) || index + 1),
+    text: toStringSafe(item.answer_text || item.answerText || item.matching_key || "Option"),
+  }));
+};
+
+const pickCorrectMatchingKey = (answers) => {
+  const match = toArray(answers).find(
+    (item) => toStringSafe(item?.matching_value).toUpperCase() === "CORRECT"
+  );
+  if (match?.matching_key) return toStringSafe(match.matching_key);
+  if (toArray(answers)[0]?.matching_key) return toStringSafe(toArray(answers)[0].matching_key);
+  return null;
+};
+
+const buildMetadataFromLegacy = (question, legacyType, groupContext = {}) => {
+  const answers = toArray(question?.answers);
+  const contentHtml = toStringSafe(question?.content);
+  const contentText = stripHtml(contentHtml) || "Question";
+
+  if (legacyType === "MCQ") {
+    let options = answers.map((ans, index) => ({
+      label: toStringSafe(ans?.matching_key || indexToKey(index) || index),
+      text: toStringSafe(ans?.answer_text || ans?.answerText),
+    }));
+
+    if (options.length < 2) {
+      options = [
+        ...options,
+        ...Array.from({ length: 2 - options.length }, (_, idx) => ({
+          label: indexToKey(options.length + idx) || String(options.length + idx + 1),
+          text: `Option ${options.length + idx + 1}`,
+        })),
+      ];
+    }
+
+    const correctOptionIndexes = answers
+      .map((ans, index) =>
+        toStringSafe(ans?.matching_value).toUpperCase() === "CORRECT" ? index : -1
+      )
+      .filter((index) => index >= 0);
+
+    return {
+      questionType: "MULTIPLE_CHOICE",
+      metadata: {
+        type: "MULTIPLE_CHOICE",
+        options,
+        correctOptionIndexes,
+        isMultiSelect: correctOptionIndexes.length > 1,
+      },
+    };
+  }
+
+  if (legacyType === "TFNG") {
+    const rawAnswer =
+      answers[0]?.answer_text || answers[0]?.matching_value || question?.answer_text || "NOT GIVEN";
+
+    return {
+      questionType: "TRUE_FALSE_NOT_GIVEN",
+      metadata: {
+        type: "TRUE_FALSE_NOT_GIVEN",
+        statement: contentText,
+        correctAnswer: normalizeNotGiven(rawAnswer),
+      },
+    };
+  }
+
+  if (legacyType === "YES_NO_NOTGIVEN") {
+    const rawAnswer =
+      answers[0]?.answer_text || answers[0]?.matching_value || question?.answer_text || "NOT GIVEN";
+
+    return {
+      questionType: "YES_NO_NOT_GIVEN",
+      metadata: {
+        type: "YES_NO_NOT_GIVEN",
+        statement: contentText,
+        correctAnswer: normalizeNotGiven(rawAnswer),
+      },
+    };
+  }
+
+  if (legacyType === "MATCHING") {
+    const options = uniqueBy(
+      answers.map((ans, index) => ({
+        label: toStringSafe(ans?.matching_key || indexToKey(index) || index),
+        text: toStringSafe(ans?.answer_text || ans?.answerText || ans?.matching_key),
+      })),
+      (item) => item.label
+    );
+
+    return {
+      questionType: "MATCHING_FEATURES",
+      metadata: {
+        type: "MATCHING_FEATURES",
+        statement: contentText,
+        features: options.length > 0 ? options : [{ label: "A", text: "Option A" }],
+        correctFeatureLabel: pickCorrectMatchingKey(answers) || "A",
+      },
+    };
+  }
+
+  if (legacyType === "LABELING") {
+    const wordBank = buildWordBankFromLegacyAnswers(answers);
+    const correctKey = pickCorrectMatchingKey(answers);
+    const correctText =
+      answers.find((ans) => toStringSafe(ans?.matching_key) === correctKey)?.answer_text ||
+      answers[0]?.answer_text ||
+      correctKey ||
+      "N/A";
+
+    const imageUrl =
+      groupContext?.imageUrl || groupContext?.img || groupContext?.groupImage || EMPTY_IMAGE_FALLBACK;
+
+    return {
+      questionType: "DIAGRAM_LABELING",
+      metadata: {
+        type: "DIAGRAM_LABELING",
+        imageUrl,
+        labelCoordinate: { x: 0, y: 0 },
+        pointLabel: toStringSafe(question?.numberQuestion || question?.questionNumber || "1"),
+        hasWordBank: wordBank.length > 0,
+        wordBank,
+        correctAnswers: ensureCorrectAnswers([correctText]),
+      },
+    };
+  }
+
+  if (legacyType === "FILL_BLANK") {
+    const hasMatchingKey = answers.some((ans) => !!ans?.matching_key);
+    const tableMode = toStringSafe(contentHtml).trim().startsWith("<table");
+
+    const correctTexts = ensureCorrectAnswers(
+      hasMatchingKey
+        ? answers
+            .filter((ans) => toStringSafe(ans?.matching_value).toUpperCase() === "CORRECT")
+            .map((ans) => ans?.answer_text)
+        : answers.map((ans) => ans?.answer_text)
+    );
+
+    if (tableMode) {
+      return {
+        questionType: "TABLE_COMPLETION",
+        metadata: {
+          type: "TABLE_COMPLETION",
+          rowIndex: 0,
+          columnIndex: 0,
+          maxWords: 5,
+          correctAnswers: correctTexts,
+        },
+      };
+    }
+
+    if (hasMatchingKey || toStringSafe(contentHtml).includes("[")) {
+      const wordBank = buildWordBankFromLegacyAnswers(answers);
+      return {
+        questionType: "SUMMARY_COMPLETION",
+        metadata: {
+          type: "SUMMARY_COMPLETION",
+          blankLabel: toStringSafe(question?.numberQuestion || question?.questionNumber || "1"),
+          maxWords: 5,
+          hasWordBank: wordBank.length > 0,
+          wordBank: wordBank.length > 0 ? wordBank : undefined,
+          correctAnswers: correctTexts,
+          fullParagraph: contentHtml,
+        },
+      };
+    }
+
+    return {
+      questionType: "SENTENCE_COMPLETION",
+      metadata: {
+        type: "SENTENCE_COMPLETION",
+        sentenceWithBlank: contentText,
+        maxWords: 5,
+        correctAnswers: correctTexts,
+      },
+    };
+  }
+
+  const fallbackCorrect =
+    answers[0]?.answer_text ||
+    question?.answer_text ||
+    stripHtml(contentHtml) ||
+    "N/A";
+
+  return {
+    questionType: "SHORT_ANSWER",
+    metadata: {
+      type: "SHORT_ANSWER",
+      maxWords: 20,
+      correctAnswers: ensureCorrectAnswers([fallbackCorrect]),
+    },
+  };
+};
+
+export const mapLegacyQuestionPayloadToBackend = (question, groupContext = {}) => {
+  const legacyType = inferLegacyTypeFromQuestion(question, groupContext);
+  const mapped = buildMetadataFromLegacy(question, legacyType, groupContext);
+
+  return {
+    idQuestionGroup: question?.idGroupOfQuestions || question?.idQuestionGroup,
+    idPart: question?.idPart,
+    questionNumber: Number(question?.numberQuestion || question?.questionNumber || 1),
+    content: toStringSafe(question?.content || stripHtml(question?.content) || "Question"),
+    questionType: mapped.questionType,
+    metadata: mapped.metadata,
+    ...(question?.idQuestion ? { idQuestion: question.idQuestion } : {}),
+  };
+};
+
+export const mapLegacyQuestionsPayloadToBackend = async (apiClient, questions) => {
+  const sourceQuestions = toArray(questions);
+  const groupIds = uniqueBy(
+    sourceQuestions
+      .map((question) => question?.idGroupOfQuestions || question?.idQuestionGroup)
+      .filter(Boolean),
+    (id) => id
+  );
+
+  const groupContextMap = {};
+
+  await Promise.all(
+    groupIds.map(async (groupId) => {
+      try {
+        const res = await apiClient.get(`/question-group/get-by-id/${groupId}`);
+        const group = res?.data?.data;
+        if (group) {
+          const decoded = decodeInstructionsAndQuantity(group.instructions, group.quantity);
+          groupContextMap[groupId] = {
+            ...group,
+            typeQuestion: mapBackendQuestionTypeToLegacyGroupType(group.questionType),
+            instructions: decoded.instructions,
+            quantity: decoded.quantity,
+            imageUrl: group.imageUrl,
+            img: group.imageUrl,
+          };
+        }
+      } catch {
+        groupContextMap[groupId] = {};
+      }
+    })
+  );
+
+  return sourceQuestions.map((question) => {
+    const groupId = question?.idGroupOfQuestions || question?.idQuestionGroup;
+    const groupContext = groupContextMap[groupId] || {};
+    return mapLegacyQuestionPayloadToBackend(question, groupContext);
+  });
+};
+
+const mapLegacyTypeToSubmitType = (legacyType) => {
+  const normalized = toStringSafe(legacyType).trim();
+  if (normalized === "MATCHING") return "MATCHING_FEATURES";
+  if (normalized === "FILL_BLANK") return "SENTENCE_COMPLETION";
+  if (normalized === "LABELING") return "DIAGRAM_LABELING";
+  return mapLegacyGroupTypeToBackendQuestionType(normalized);
+};
+
+export const mapLegacyAnswerToSubmitItem = (answer, fallbackLegacyType = null) => {
+  if (answer?.answerType && answer?.answerPayload) {
+    return {
+      idQuestion: toStringSafe(answer.idQuestion),
+      answerType: answer.answerType,
+      answerPayload: answer.answerPayload,
+    };
+  }
+
+  const rawLegacyType = answer?.userAnswerType || fallbackLegacyType || "SHORT_ANSWER";
+  const answerType = mapLegacyTypeToSubmitType(rawLegacyType);
+
+  const answerText = toStringSafe(
+    answer?.answerText || answer?.answer_text || answer?.text || ""
+  );
+  const matchingKey = answer?.matching_key ?? null;
+  const matchingValue = answer?.matching_value ?? null;
+
+  let answerPayload = { type: answerType, answerText };
+
+  if (answerType === "MULTIPLE_CHOICE") {
+    const singleIndex = keyToIndex(matchingKey);
+    answerPayload = {
+      type: "MULTIPLE_CHOICE",
+      selectedIndexes: singleIndex >= 0 ? [singleIndex] : [],
+    };
+  } else if (answerType === "TRUE_FALSE_NOT_GIVEN") {
+    answerPayload = {
+      type: "TRUE_FALSE_NOT_GIVEN",
+      answer: normalizeNotGiven(matchingValue || answerText || "NOT GIVEN"),
+    };
+  } else if (answerType === "YES_NO_NOT_GIVEN") {
+    answerPayload = {
+      type: "YES_NO_NOT_GIVEN",
+      answer: normalizeNotGiven(matchingValue || answerText || "NOT GIVEN"),
+    };
+  } else if (answerType.startsWith("MATCHING_")) {
+    answerPayload = {
+      type: answerType,
+      selectedLabel: toStringSafe(matchingKey || answerText),
+    };
+  } else if (answerType === "DIAGRAM_LABELING") {
+    answerPayload = {
+      type: "DIAGRAM_LABELING",
+      answerText: answerText || toStringSafe(matchingKey),
+    };
+  } else {
+    answerPayload = {
+      type: answerType,
+      answerText: answerText || toStringSafe(matchingValue),
+    };
+  }
+
+  return {
+    idQuestion: toStringSafe(answer?.idQuestion),
+    answerType,
+    answerPayload,
+  };
+};
+
+export const mapLegacyAnswersToSubmitItems = (answers, fallbackTypeMap = {}) => {
+  const grouped = new Map();
+
+  toArray(answers).forEach((answer) => {
+    const idQuestion = toStringSafe(answer?.idQuestion);
+    if (!idQuestion) return;
+
+    const fallbackType = fallbackTypeMap[idQuestion] || null;
+    const mapped = mapLegacyAnswerToSubmitItem(answer, fallbackType);
+    const existing = grouped.get(idQuestion);
+
+    if (!existing) {
+      grouped.set(idQuestion, mapped);
+      return;
+    }
+
+    if (mapped.answerType === "MULTIPLE_CHOICE") {
+      const mergedIndexes = uniqueBy(
+        [...toArray(existing.answerPayload?.selectedIndexes), ...toArray(mapped.answerPayload?.selectedIndexes)].map((idx) => Number(idx)),
+        (idx) => idx
+      ).filter((idx) => Number.isFinite(idx) && idx >= 0);
+
+      grouped.set(idQuestion, {
+        ...existing,
+        answerType: "MULTIPLE_CHOICE",
+        answerPayload: {
+          type: "MULTIPLE_CHOICE",
+          selectedIndexes: mergedIndexes,
+        },
+      });
+      return;
+    }
+
+    if (mapped.answerType.startsWith("MATCHING_")) {
+      const selectedLabel =
+        toStringSafe(mapped.answerPayload?.selectedLabel) ||
+        toStringSafe(existing.answerPayload?.selectedLabel);
+
+      grouped.set(idQuestion, {
+        ...existing,
+        answerType: mapped.answerType,
+        answerPayload: {
+          type: mapped.answerType,
+          selectedLabel,
+        },
+      });
+      return;
+    }
+
+    grouped.set(idQuestion, mapped);
+  });
+
+  return Array.from(grouped.values());
+};


### PR DESCRIPTION
- add service adapter layer to map legacy UI schema to new backend contracts

- migrate reading/listening flow to save-progress + submit-reading-listening + reset-test routes

- map legacy answers to answerType/answerPayload and normalize result payload back to legacy shape

- migrate teacher question-group/question APIs to new namespaces and metadata model

- fix speaking task route and writing submission contract (submissionText + idTestResult path param)

- fix high-priority mismatches: user delete route, forum delete idUser body, vocab add-topic payload

- harden auth flows: resend OTP type mapping and Google callback refreshToken handling

- fix teacher test edit route param/navigation mismatch

- add refactor stability README for tracked contract migration findings