### PR TITLE
Remove grammar routes from admin navbar and router

### DIFF
--- a/src/components/ui/navBar/navBarAdmin.jsx
+++ b/src/components/ui/navBar/navBarAdmin.jsx
@@ -23,7 +23,6 @@ const adminLinks = [
   { name: "Users", href: "/admin/userList", icon: Users },
   { name: "Moderation", href: "/admin/moderation", icon: FileCheck },
   { name: "Content", href: "/admin/testManager", icon: FileStack },
-  { name: "Grammar", href: "/admin/grammar", icon: BookOpen },
   { name: "Vocabulary", href: "/admin/vocabulary", icon: BookMarked },
   { name: "Chấm bài", href: "/admin/teacher-review", icon: ClipboardCheck },
 ];

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -147,8 +147,6 @@ const router = createBrowserRouter([
           { path: "testManager/testCreate", element: <LazyRoute Component={TestCreate} /> },
           { path: "testManager/testEdit/:id", element: <LazyRoute Component={TestEdit} /> },
           { path: "testManager", element: <LazyRoute Component={TestManager} /> },
-          { path: "grammar", element: <LazyRoute Component={Grammar} /> },
-          { path: "grammar-practice", element: <LazyRoute Component={GrammarPractice} /> },
           { path: "moderation", element: <LazyRoute Component={ForumModeration} /> },
           { path: "teacher-review", element: <LazyRoute Component={TeacherReviewManager} /> },
         ],


### PR DESCRIPTION
Grammar feature is being removed from admin panel per direction to focus on core features.