### PR TITLE
fix: align magicpath submit payload with BE contract + guard against …

### DIFF
--- a/src/Pages/client/test/doTest.jsx
+++ b/src/Pages/client/test/doTest.jsx
@@ -1,0 +1,363 @@
+// doTest.jsx
+// Page wrapper (Plan A pattern) dispatch magicpath screen vs code cũ.
+//
+// Logic:
+//   previewMode=true                          → render code cũ (teacher preview)
+//   initialTestResult?.finishedAt            → render code cũ (review mode)
+//   testType === 'SPEAKING'                  → render code cũ (chưa có magicpath speaking)
+//   testType in [LISTENING, READING, WRITING] → render magicpath screen mới
+
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { Modal, Spin, message } from "antd";
+import { useAuth } from "@/context/authContext";
+
+import {
+  getDetailInTestAPI,
+  getTestResultAndAnswersAPI,
+  StartTestAPI,
+  findAllTestResultByIdUserAPI,
+} from "@/services/apiDoTest";
+import { getAllWritingTasksAPI } from "@/services/apiWriting";
+import {
+  toMagicpathShape,
+  buildAnswersMapForMagicpath,
+} from "@/services/magicpathAdapter";
+
+// Code cũ — giữ cho teacher preview + review + Speaking fallback
+import Listening from "@/components/test/type/listening";
+import Reading from "@/components/test/type/reading";
+import Writing from "@/components/test/type/writing";
+import Speaking from "@/components/test/type/speaking";
+
+// Magicpath screens
+import { IELTSListeningTestScreen } from "@/components/magicpath/ielts-listening-test-screen/IELTSListeningTestScreen";
+import { IELTSReadingTestScreen } from "@/components/magicpath/ielts-reading-test-screen/IELTSReadingTestScreen";
+import { IELTSWritingTestScreen } from "@/components/magicpath/ielts-writing-test-screen/IELTSWritingTestScreen";
+
+const oldComponents = {
+  LISTENING: Listening,
+  READING: Reading,
+  WRITING: Writing,
+  SPEAKING: Speaking,
+};
+
+const MAGIC_PATH_TYPES = new Set(["LISTENING", "READING", "WRITING"]);
+
+const DoTest = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const params = useParams();
+  const { user } = useAuth();
+
+  const searchParams = new URLSearchParams(location.search);
+  const previewMode = searchParams.get("preview") === "teacher";
+  const routeId = params.id || params.idTest;
+  const state = location.state || {};
+  const idTest = state.idTest || routeId;
+  const testType = state.testType;
+  const duration = state.duration;
+  const initialTestResult = state.initialTestResult;
+
+  const [loading, setLoading] = useState(!testType);
+  const [test, setTest] = useState(null);
+  const [testResultId, setTestResultId] = useState(
+    initialTestResult?.idTestResult || initialTestResult?.id || null
+  );
+  const [userAnswers, setUserAnswers] = useState(
+    initialTestResult?.userAnswer || []
+  );
+  const [writingTasks, setWritingTasks] = useState([]);
+  const [timedOut, setTimedOut] = useState(false);
+  const [alreadyFinished, setAlreadyFinished] = useState(null);
+  // alreadyFinished shape: { idTestResult, finishedAt, bandScore } | null
+  // null = chưa check xong hoặc chưa làm
+
+  const resolvedType = (test?.testType || testType || "").toUpperCase();
+  const finishedAt = initialTestResult?.finishedAt;
+  const useOld =
+    previewMode ||
+    !!finishedAt ||
+    !MAGIC_PATH_TYPES.has(resolvedType);
+
+  // Timeout guard
+  useEffect(() => {
+    if (!idTest) {
+      const t = setTimeout(() => setTimedOut(true), 5000);
+      return () => clearTimeout(t);
+    }
+  }, [idTest]);
+
+  useEffect(() => {
+    if (!idTest) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const res = await getDetailInTestAPI(idTest);
+        if (cancelled) return;
+        setTest(res?.data || null);
+      } catch (err) {
+        console.error("getDetailInTestAPI error:", err);
+        message.error("Không tải được dữ liệu đề thi.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [idTest]);
+
+  // Guard: nếu user navigate thẳng tới /do-test/:id (go back, deep link, …)
+  // mà user đã hoàn thành bài này rồi (status FINISHED) thì block,
+  // show modal + điều hướng về trang test list. Tránh bị BE trả 400
+  // "This test has already been submitted" khi autosave/submit.
+  // Bỏ qua khi review mode (finishedAt có sẵn) hoặc teacher preview.
+  useEffect(() => {
+    if (previewMode) return;
+    if (finishedAt) return;
+    if (!idTest || !user?.idUser) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await findAllTestResultByIdUserAPI(user.idUser);
+        if (cancelled) return;
+        const list = (res?.data || []).filter(
+          (r) => r?.idTest === idTest
+        );
+        // Mỗi lần startTest → tạo row mới trong userTestResult. Nhiều row
+        // cho cùng idTest có thể tồn tại (làm nhiều lần, hoặc đang có
+        // phiên IN_PROGRESS chưa nộp). Lấy row mới nhất theo createdAt —
+        // nếu nó FINISHED thì block, nếu IN_PROGRESS thì cho resume.
+        // KHÔNG phụ thuộc sort của BE — sort tại FE để an toàn.
+        const latest = list
+          .slice()
+          .sort(
+            (a, b) =>
+              new Date(b.createdAt || 0) - new Date(a.createdAt || 0)
+          )[0];
+        if (latest?.status === "FINISHED") {
+          setAlreadyFinished({
+            idTestResult: latest.idTestResult || latest.id || null,
+            finishedAt: latest.finishedAt || null,
+            bandScore: latest.bandScore ?? null,
+          });
+        }
+      } catch (err) {
+        // Lỗi check lịch sử không nên block UI — để user vào làm,
+        // BE vẫn là source of truth, lỗi sẽ được xử lý khi submit.
+        console.warn("findAllTestResultByIdUserAPI error:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [previewMode, finishedAt, idTest, user?.idUser]);
+
+  // Khi dùng magicpath + chưa có testResultId → tạo mới
+  useEffect(() => {
+    if (useOld) return;
+    if (testResultId) return;
+    if (!idTest || !user?.idUser) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await StartTestAPI(user.idUser, idTest, {});
+        if (cancelled) return;
+        const data = res?.data || res;
+        setTestResultId(data?.idTestResult || data?.id || null);
+        setUserAnswers(data?.userAnswer || []);
+      } catch (err) {
+        console.error("StartTestAPI error:", err);
+        // Không block UI — magicpath screen sẽ tự handle khi submit
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [useOld, testResultId, idTest, user?.idUser]);
+
+  // Load writingTasks nếu Writing
+  useEffect(() => {
+    if (useOld) return;
+    if (resolvedType !== "WRITING") return;
+    if (!idTest) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await getAllWritingTasksAPI(idTest);
+        if (cancelled) return;
+        const arr = Array.isArray(res?.data)
+          ? res.data
+          : Array.isArray(res)
+            ? res
+            : [];
+        setWritingTasks(arr);
+      } catch (err) {
+        console.error("getAllWritingTasksAPI error:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [useOld, resolvedType, idTest]);
+
+  // Nếu có testResultId nhưng chưa có userAnswers (resume flow) → fetch
+  useEffect(() => {
+    if (useOld) return;
+    if (!testResultId) return;
+    if (userAnswers.length > 0) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await getTestResultAndAnswersAPI(testResultId);
+        if (cancelled) return;
+        const data = res?.data || res;
+        setUserAnswers(data?.userAnswer || []);
+      } catch (err) {
+        console.error("getTestResultAndAnswersAPI error:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [useOld, testResultId, userAnswers.length]);
+
+  const testDataMagicpath = useMemo(() => {
+    if (useOld || !test) return null;
+    const answersMap = buildAnswersMapForMagicpath(userAnswers);
+    return toMagicpathShape(test, answersMap);
+  }, [useOld, test, userAnswers]);
+
+  const initialAnswersForMagicpath = useMemo(() => {
+    return buildAnswersMapForMagicpath(userAnswers);
+  }, [userAnswers]);
+
+  const handleSubmitSuccess = (result) => {
+    const id = result?.idTestResult || result?.id || testResultId;
+    if (id) {
+      navigate(`/test/review/${id}`);
+    } else {
+      navigate("/test");
+    }
+  };
+
+  if (timedOut) {
+    return (
+      <div className="text-center py-12 text-gray-500">
+        Không tải được dữ liệu đề thi. Quay lại trang Test...
+      </div>
+    );
+  }
+
+  // Block khi user đã hoàn thành bài này (go back / deep link).
+  // Hiện modal 1 lần — user chọn "Xem kết quả" hoặc "Về trang Test".
+  if (alreadyFinished) {
+    const reviewId = alreadyFinished.idTestResult || testResultId;
+    return (
+      <Modal
+        open
+        title="Bài thi đã được nộp"
+        okText={reviewId ? "Xem kết quả" : "Về trang Test"}
+        cancelText="Về trang Test"
+        showCancel
+        closable={false}
+        maskClosable={false}
+        onOk={() => {
+          if (reviewId) navigate(`/test/review/${reviewId}`);
+          else navigate("/test");
+        }}
+        onCancel={() => navigate("/test")}
+      >
+        <p>Bạn đã hoàn thành bài thi này rồi và không thể làm lại.</p>
+        {alreadyFinished.finishedAt && (
+          <p className="text-gray-500 text-sm mt-2">
+            Hoàn thành lúc:{" "}
+            {new Date(alreadyFinished.finishedAt).toLocaleString("vi-VN")}
+          </p>
+        )}
+        {typeof alreadyFinished.bandScore === "number" && (
+          <p className="text-gray-500 text-sm mt-1">
+            Band: {alreadyFinished.bandScore}
+          </p>
+        )}
+      </Modal>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="text-center py-12">
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!idTest || !resolvedType) {
+    return (
+      <div className="text-center py-12 text-gray-500">
+        Không đủ dữ liệu để preview đề.
+      </div>
+    );
+  }
+
+  // Code cũ (teacher preview, review mode, Speaking)
+  if (useOld) {
+    const OldComp = oldComponents[resolvedType];
+    if (!OldComp) {
+      return (
+        <div className="text-center py-12 text-gray-500">
+          Không tìm thấy loại đề: {resolvedType}
+        </div>
+      );
+    }
+    return (
+      <OldComp
+        idTest={idTest}
+        duration={duration || test?.duration}
+        initialTestResult={initialTestResult}
+        previewMode={previewMode}
+      />
+    );
+  }
+
+  // Magicpath
+  if (!testDataMagicpath) {
+    return (
+      <div className="text-center py-12">
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  const commonProps = {
+    testData: testDataMagicpath,
+    testResultId: testResultId || undefined,
+    userId: user?.idUser,
+    onSubmitSuccess: handleSubmitSuccess,
+  };
+
+  if (resolvedType === "LISTENING") {
+    return <IELTSListeningTestScreen {...commonProps} initialAnswers={initialAnswersForMagicpath} />;
+  }
+  if (resolvedType === "READING") {
+    return <IELTSReadingTestScreen {...commonProps} initialAnswers={initialAnswersForMagicpath} />;
+  }
+  if (resolvedType === "WRITING") {
+    return (
+      <IELTSWritingTestScreen
+        {...commonProps}
+        writingTasks={writingTasks}
+        initialAnswers={initialAnswersForMagicpath}
+      />
+    );
+  }
+  return (
+    <div className="text-center py-12 text-gray-500">
+      Không tìm thấy loại đề: {resolvedType}
+    </div>
+  );
+};
+
+export default DoTest;

--- a/src/components/magicpath/ielts-listening-test-screen/IELTSListeningTestScreen.jsx
+++ b/src/components/magicpath/ielts-listening-test-screen/IELTSListeningTestScreen.jsx
@@ -1,0 +1,545 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { createManyAnswersAPI, FinistTestAPI } from '@/services/apiDoTest';
+import { buildLegacyAnswerForAdapter } from '@/services/contractAdapters';
+import { toast } from 'react-toastify';
+
+const TONE_STYLES = {
+  indigo: 'bg-[#6366f1] text-white shadow-[0_4px_0_#4338ca] hover:brightness-110',
+  cyan: 'bg-[#06b6d4] text-white shadow-[0_4px_0_#0891b2] hover:brightness-110',
+  coral: 'bg-[#fb7185] text-white shadow-[0_4px_0_#e11d48] hover:brightness-110',
+  amber: 'bg-[#f59e0b] text-white shadow-[0_4px_0_#b45309] hover:brightness-110',
+  ghost: 'bg-white text-[#6366f1] border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]',
+};
+const SIZE_STYLES = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-5 py-2.5 text-sm',
+  lg: 'px-7 py-3.5 text-base',
+};
+
+function StackedButton({ children, tone = 'indigo', onClick, size = 'md', disabled }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`${TONE_STYLES[tone]} ${SIZE_STYLES[size]} font-extrabold uppercase tracking-wide rounded-2xl active:translate-y-[2px] active:shadow-[0_2px_0] transition-all disabled:opacity-50 disabled:cursor-not-allowed`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function PaletteCell({ num, state, active, onClick }) {
+  const base = 'relative w-9 h-9 rounded-xl text-xs font-extrabold transition-all border-2 flex items-center justify-center';
+  let cls = '';
+  if (active) cls = 'bg-[#6366f1] text-white border-[#4338ca] shadow-[0_3px_0_#4338ca] scale-110';
+  else if (state === 'flagged') cls = 'bg-[#fff1f2] text-[#e11d48] border-[#fb7185] shadow-[0_2px_0_#e11d48]';
+  else if (state === 'answered') cls = 'bg-[#eef2ff] text-[#4338ca] border-[#a5b4fc] shadow-[0_2px_0_#a5b4fc]';
+  else cls = 'bg-white text-[#64748b] border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]';
+  return (
+    <button onClick={onClick} className={`${base} ${cls}`}>
+      {num}
+      {state === 'flagged' && <span className="absolute -top-1 -right-1 w-3 h-3 bg-[#fb7185] rounded-full ring-2 ring-white" />}
+    </button>
+  );
+}
+
+function MCQOption({ letter, text, selected, onClick }) {
+  return (
+    <button onClick={onClick} className={`w-full flex items-start gap-3 p-3 rounded-2xl border-2 text-left transition-all ${selected ? 'bg-[#eef2ff] border-[#6366f1] shadow-[0_2px_0_#4338ca]' : 'bg-white border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]'}`}>
+      <div className={`flex-none w-8 h-8 rounded-xl flex items-center justify-center font-black text-sm ${selected ? 'bg-[#6366f1] text-white' : 'bg-[#f1f1f6] text-[#64748b]'}`}>{letter}</div>
+      <div className="flex-1 pt-1 text-sm font-semibold text-[#1e1b4b]">{text}</div>
+      {selected && <div className="text-[#6366f1] text-lg">✓</div>}
+    </button>
+  );
+}
+
+function MatchingQuestion({ question, options, value, onChange }) {
+  const letters = options.map((_, i) => String.fromCharCode(65 + i));
+  return (
+    <div className="space-y-3">
+      <div className="bg-[#eef2ff] border-2 border-[#a5b4fc] rounded-2xl p-3">
+        <div className="text-[10px] font-bold uppercase tracking-wider text-[#6366f1] mb-2">Word bank</div>
+        <div className="flex flex-wrap gap-1.5">
+          {options.map((opt, idx) => (
+            <div key={idx} className="inline-flex items-center gap-1.5 px-2 py-1 rounded-xl bg-white border-2 border-[#a5b4fc]">
+              <span className="w-5 h-5 rounded-md bg-[#6366f1] text-white text-[10px] font-black flex items-center justify-center">{String.fromCharCode(65 + idx)}</span>
+              <span className="text-xs font-semibold text-[#1e1b4b]">{opt.text || opt.matching_key}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {options.map((_, idx) => {
+          const letter = String.fromCharCode(65 + idx);
+          const selected = value === letter;
+          return (
+            <button key={letter} onClick={() => onChange(letter)} className={`w-11 h-11 rounded-2xl font-black text-sm transition-all border-2 ${selected ? 'bg-[#6366f1] text-white border-[#4338ca] shadow-[0_3px_0_#4338ca]' : 'bg-white text-[#1e1b4b] border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]'}`}>
+              {letter}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function LabelingQuestion({ question, options, imageUrl, value, onChange }) {
+  return (
+    <div className="space-y-3">
+      {imageUrl && (
+        <div className="bg-[#fafafc] border-2 border-[#e6e6ed] rounded-2xl p-2 flex items-center justify-center">
+          <img src={imageUrl} alt="diagram" className="max-w-full max-h-64 object-contain" />
+        </div>
+      )}
+      <div className="bg-[#eef2ff] border-2 border-[#a5b4fc] rounded-2xl p-3">
+        <div className="text-[10px] font-bold uppercase tracking-wider text-[#6366f1] mb-2">Word bank</div>
+        <div className="flex flex-wrap gap-1.5">
+          {options.map((opt, idx) => (
+            <div key={idx} className="inline-flex items-center gap-1.5 px-2 py-1 rounded-xl bg-white border-2 border-[#a5b4fc]">
+              <span className="w-5 h-5 rounded-md bg-[#6366f1] text-white text-[10px] font-black flex items-center justify-center">{opt.matching_key || String.fromCharCode(65 + idx)}</span>
+              <span className="text-xs font-semibold text-[#1e1b4b]">{opt.text || opt.answer_text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <select value={value || ''} onChange={(e) => onChange(e.target.value)} className="w-full px-3 py-3 rounded-2xl border-2 border-[#e6e6ed] focus:border-[#6366f1] focus:shadow-[0_0_0_4px_rgba(99,102,241,0.18)] bg-white font-semibold outline-none transition-all">
+        <option value="">— Chọn —</option>
+        {options.map((opt, idx) => {
+          const key = opt.matching_key || String.fromCharCode(65 + idx);
+          return <option key={idx} value={key}>{key}. {opt.text || opt.answer_text}</option>;
+        })}
+      </select>
+    </div>
+  );
+}
+
+function Waveform({ progress, playing }) {
+  const bars = 64;
+  return (
+    <div className="flex items-center gap-[2px] h-12 w-full">
+      {Array.from({ length: bars }).map((_, i) => {
+        const pct = (i / bars) * 100;
+        const past = pct < progress;
+        const seed = Math.sin(i * 12.9898) * 43758.5453;
+        const h = 14 + Math.abs(seed - Math.floor(seed)) * 30;
+        const isLive = playing && Math.abs(pct - progress) < 1.5;
+        return (
+          <motion.div
+            key={i}
+            animate={isLive ? { scaleY: [1, 1.6, 1] } : { scaleY: 1 }}
+            transition={isLive ? { duration: 0.4, repeat: Infinity } : {}}
+            className={`flex-1 rounded-full origin-center ${past ? 'bg-[#6366f1]' : 'bg-[#e6e6ed]'} ${isLive ? '!bg-[#fb7185]' : ''}`}
+            style={{ height: `${h}px` }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+const fmt = (s) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+
+export const IELTSListeningTestScreen = ({ testData, testResultId, userId, initialAnswers, onSubmitSuccess }) => {
+  const sections = useMemo(() => {
+    const parts = testData?.parts || [];
+    if (parts.length === 0) return [];
+    return parts.map((s, idx) => {
+      const groupQs = (s?.questionGroups || []).flatMap((g) => g?.questions || g?.question || []);
+      const start = idx === 0 ? 1 : (() => { let c = 1; for (let i = 0; i < idx; i++) { c += (parts[i]?.questionGroups || []).reduce((acc, g) => acc + (g?.questions || g?.question || []).length, 0); } return c; })();
+      const end = start + groupQs.length - 1;
+      return {
+        id: s.id ?? idx + 1,
+        title: s.title || `Section ${idx + 1}`,
+        context: s.context || s.description || s?.passage?.content || '',
+        questionRange: [start, Math.max(end, start)],
+      };
+    });
+  }, [testData]);
+
+  const questions = useMemo(() => {
+    const parts = testData?.parts || [];
+    const flat = parts.flatMap((p) =>
+      (p?.questionGroups || []).flatMap((g) => g?.questions || g?.question || [])
+    );
+    return flat.map((q, idx) => {
+      const wordBank = (q.answers || []).map((a) => ({
+        text: a.answer_text || a.text || '',
+        matching_key: a.matching_key || a.label || '',
+      }));
+      const options = (q.options && q.options.length > 0) ? q.options : wordBank;
+      return {
+        id: q.id || q.questionNumber || idx + 1,
+        displayNum: idx + 1,
+        type: q.type || q.questionType || 'FILL_BLANK',
+        prompt: q.prompt || q.content || q.questionText || '',
+        options,
+        wordBank,
+        imageUrl: q.imageUrl || null,
+        answer: q.userAnswer || '',
+      };
+    });
+  }, [testData]);
+
+  const totalQuestions = questions.length;
+  const totalSeconds = (testData?.durationMinutes || 30) * 60;
+  const audioUrl = testData?.audioUrl || testData?.listeningAudio;
+
+  const [answers, setAnswers] = useState(() => {
+    const init = {};
+    const seed = initialAnswers || {};
+    questions.forEach((q) => {
+      const val = seed[q.id] ?? seed[String(q.id)] ?? q.answer;
+      if (val) init[q.id] = val;
+    });
+    return init;
+  });
+  const [flagged, setFlagged] = useState({});
+  const [activeId, setActiveId] = useState(questions[0]?.id || 1);
+  const [playing, setPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [secondsLeft, setSecondsLeft] = useState(totalSeconds);
+  const [submitting, setSubmitting] = useState(false);
+  const audioRef = useRef(null);
+  const intervalRef = useRef(null);
+  const autosaveRef = useRef(null);
+
+  // Timer — auto submit khi hết giờ
+  useEffect(() => {
+    if (secondsLeft <= 0) {
+      handleSubmit();
+      return;
+    }
+    const t = setInterval(() => setSecondsLeft((s) => s - 1), 1000);
+    return () => clearInterval(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [secondsLeft]);
+
+  // Audio progress (mock — không dùng audio thật)
+  useEffect(() => {
+    if (playing) {
+      intervalRef.current = setInterval(() => setProgress((p) => (p < 100 ? p + 0.5 : 100)), 200);
+    } else if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
+  }, [playing]);
+
+  // Build legacy-shape answer items the contract adapter can convert.
+  // Defined BEFORE the autosave useEffect that depends on it.
+  const answersToLegacyPayload = useCallback(() => {
+    return Object.entries(answers)
+      .map(([qid, val]) => {
+        const q = questions.find((x) => x.id === qid || x.id === Number(qid) || String(x.id) === qid);
+        return buildLegacyAnswerForAdapter(qid, val, q?.type);
+      })
+      .filter(Boolean);
+  }, [answers, questions]);
+
+  // Autosave (debounce 1.5s)
+  useEffect(() => {
+    if (!testResultId || !userId) return;
+    if (autosaveRef.current) clearTimeout(autosaveRef.current);
+    autosaveRef.current = setTimeout(() => {
+      const payload = answersToLegacyPayload();
+      if (payload.length === 0) return;
+      createManyAnswersAPI(userId, testResultId, { answers: payload }).catch((e) => {
+        console.warn('autosave failed', e);
+      });
+    }, 1500);
+    return () => { if (autosaveRef.current) clearTimeout(autosaveRef.current); };
+  }, [answers, testResultId, userId, answersToLegacyPayload]);
+
+  const setAnswer = useCallback((qid, val) => {
+    setAnswers((prev) => ({ ...prev, [qid]: val }));
+  }, []);
+
+  const toggleFlag = useCallback((qid) => {
+    setFlagged((prev) => ({ ...prev, [qid]: !prev[qid] }));
+  }, []);
+
+  const getState = useCallback((qid) => {
+    if (flagged[qid]) return 'flagged';
+    if (answers[qid]) return 'answered';
+    return 'unanswered';
+  }, [flagged, answers]);
+
+  const active = questions.find((q) => q.id === activeId);
+  const activeState = active ? getState(active.id) : 'unanswered';
+  const answeredCount = Object.keys(answers).filter((k) => answers[k]).length;
+  const overallProgress = totalQuestions ? (answeredCount / totalQuestions) * 100 : 0;
+
+  const goNext = () => {
+    const idx = questions.findIndex((q) => q.id === activeId);
+    if (idx < questions.length - 1) setActiveId(questions[idx + 1].id);
+  };
+  const goPrev = () => {
+    const idx = questions.findIndex((q) => q.id === activeId);
+    if (idx > 0) setActiveId(questions[idx - 1].id);
+  };
+
+  const handleSubmit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const payload = answersToLegacyPayload();
+      const result = await FinistTestAPI(testResultId, userId, {
+        answers: payload,
+        duration: totalSeconds - secondsLeft,
+      });
+      toast.success('Nộp bài thành công!');
+      if (onSubmitSuccess) onSubmitSuccess(result);
+    } catch (e) {
+      console.error('submit failed', e);
+      toast.error('Nộp bài thất bại. Vui lòng thử lại.');
+      setSubmitting(false);
+    }
+  };
+
+  if (!testData || questions.length === 0) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-[#64748b]">
+        Không có câu hỏi nào.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen w-full bg-[#fafafc] flex flex-col">
+      <audio ref={audioRef} src={audioUrl} onEnded={() => setPlaying(false)} />
+
+      {/* Top bar */}
+      <header className="sticky top-0 z-30 bg-white/95 backdrop-blur border-b-2 border-[#e6e6ed]">
+        <div className="max-w-[1440px] mx-auto px-6 py-3 flex items-center gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-2xl bg-gradient-to-br from-[#6366f1] to-[#a855f7] shadow-[0_3px_0_#4338ca] flex items-center justify-center text-lg">🦉</div>
+            <div className="hidden sm:block">
+              <div className="text-[10px] font-bold uppercase tracking-wider text-[#64748b]">IELTS Listening</div>
+              <div className="text-sm font-extrabold text-[#1e1b4b]">{testData?.title || 'Test'}</div>
+            </div>
+          </div>
+
+          <div className="flex-1 min-w-[200px] max-w-md mx-auto">
+            <div className="flex items-center gap-2 text-xs font-bold text-[#64748b] mb-1.5">
+              <span>{answeredCount}/{totalQuestions} đã trả lời</span>
+              <span className="ml-auto text-[#6366f1]">{Math.round(overallProgress)}%</span>
+            </div>
+            <div className="h-2.5 bg-[#f1f1f6] rounded-full overflow-hidden">
+              <motion.div animate={{ width: `${overallProgress}%` }} className="h-full bg-gradient-to-r from-[#6366f1] via-[#06b6d4] to-[#fb7185] rounded-full" />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 px-4 py-2 rounded-2xl font-mono font-black text-lg bg-[#eef2ff] text-[#4338ca] border-2 border-[#a5b4fc] shadow-[0_3px_0_#a5b4fc]">
+            <span>⏱</span>
+            <span>{fmt(secondsLeft)}</span>
+          </div>
+
+          <StackedButton tone="coral" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? 'Đang nộp...' : 'Nộp bài'}
+          </StackedButton>
+        </div>
+      </header>
+
+      {/* Section ribbon */}
+      {sections.length > 0 && (
+        <div className="bg-white border-b-2 border-[#e6e6ed]">
+          <div className="max-w-[1440px] mx-auto px-6 py-3 flex items-center gap-3 overflow-x-auto">
+            {sections.map((s, i) => {
+              const isCurrent = activeId >= s.questionRange[0] && activeId <= s.questionRange[1];
+              const isDone = s.questionRange[1] < activeId;
+              return (
+                <div key={s.id} className="flex items-center gap-3 flex-none">
+                  <div className={`flex items-center gap-3 px-4 py-2 rounded-2xl border-2 ${isCurrent ? 'bg-[#eef2ff] border-[#6366f1] shadow-[0_2px_0_#4338ca]' : isDone ? 'bg-[#d1fae5] border-[#10b981]/40' : 'bg-white border-[#e6e6ed]'}`}>
+                    <div className={`w-8 h-8 rounded-xl flex items-center justify-center text-sm font-black ${isCurrent ? 'bg-[#6366f1] text-white' : isDone ? 'bg-[#10b981] text-white' : 'bg-[#f1f1f6] text-[#64748b]'}`}>
+                      {isDone ? '✓' : s.id}
+                    </div>
+                    <div>
+                      <div className={`text-xs font-extrabold ${isCurrent ? 'text-[#4338ca]' : isDone ? 'text-[#047857]' : 'text-[#64748b]'}`}>{s.title}</div>
+                      <div className="text-[10px] text-[#64748b]">{s.context} · Q{s.questionRange[0]}-{s.questionRange[1]}</div>
+                    </div>
+                  </div>
+                  {i < sections.length - 1 && <div className="w-6 h-0.5 bg-[#e6e6ed]" />}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Main */}
+      <main className="flex-1 max-w-[1440px] w-full mx-auto px-6 py-6 grid grid-cols-1 lg:grid-cols-[1fr_1.1fr_240px] gap-6">
+        <section className="space-y-4 lg:sticky lg:top-[160px] lg:self-start">
+          <div className="bg-gradient-to-br from-[#1e1b4b] via-[#312e81] to-[#4338ca] text-white rounded-3xl shadow-[0_3px_0_#0b0a1f] p-6 overflow-hidden relative">
+            <div className="absolute -top-8 -right-8 w-40 h-40 bg-[#6366f1]/30 rounded-full blur-2xl" />
+            <div className="absolute bottom-0 left-0 w-32 h-32 bg-[#fb7185]/20 rounded-full blur-2xl" />
+            <div className="relative">
+              <div className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider opacity-80 mb-1">
+                <span className={`inline-block w-2 h-2 rounded-full ${playing ? 'bg-[#fb7185] animate-pulse' : 'bg-white/40'}`} />
+                {playing ? 'Đang phát' : 'Sẵn sàng'}
+              </div>
+              <h2 className="text-2xl font-black mb-1" style={{ fontFamily: 'Nunito' }}>Listening Audio</h2>
+              <p className="text-sm opacity-80 mb-5">{testData?.audioDescription || 'Nghe kỹ và trả lời các câu hỏi bên dưới.'}</p>
+
+              <Waveform progress={progress} playing={playing} />
+
+              <div className="flex items-center justify-between text-xs font-mono mt-2 opacity-90">
+                <span>{fmt(Math.floor((progress / 100) * totalSeconds))}</span>
+                <span>{fmt(totalSeconds)}</span>
+              </div>
+
+              <div className="flex items-center justify-between mt-5">
+                <div className="flex items-center gap-2">
+                  <button onClick={() => { if (audioRef.current) audioRef.current.currentTime = Math.max(0, audioRef.current.currentTime - 10); }} className="w-10 h-10 rounded-xl bg-white/10 hover:bg-white/20 flex items-center justify-center text-lg" title="Lùi 10s">⏮</button>
+                  <button
+                    onClick={() => {
+                      if (audioRef.current) {
+                        if (playing) { audioRef.current.pause(); setPlaying(false); }
+                        else { audioRef.current.play().catch(() => {}); setPlaying(true); }
+                      } else {
+                        setPlaying((p) => !p);
+                      }
+                    }}
+                    className="w-14 h-14 rounded-2xl bg-white text-[#4338ca] shadow-[0_4px_0_rgba(0,0,0,0.25)] flex items-center justify-center text-2xl active:translate-y-[2px] active:shadow-[0_2px_0_rgba(0,0,0,0.25)] transition-all"
+                  >
+                    {playing ? '⏸' : '▶'}
+                  </button>
+                  <button onClick={() => { if (audioRef.current) audioRef.current.currentTime = Math.min(audioRef.current.duration || 0, audioRef.current.currentTime + 10); }} className="w-10 h-10 rounded-xl bg-white/10 hover:bg-white/20 flex items-center justify-center text-lg" title="Tới 10s">⏭</button>
+                </div>
+                <button className="w-9 h-9 rounded-xl bg-white/10 hover:bg-white/20 flex items-center justify-center text-sm" title="Volume">🔊</button>
+              </div>
+
+              <div className="mt-5 pt-5 border-t border-white/15 flex items-start gap-3">
+                <div className="text-2xl">⚠️</div>
+                <div className="text-xs leading-relaxed opacity-90">
+                  <strong className="block mb-0.5">Audio chỉ phát 1 lần</strong>
+                  Bài thi thật không cho tua. Tập trung lắng nghe và ghi đáp án trong khi nghe.
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-3xl border-2 border-dashed border-[#e6e6ed] p-5 text-center">
+            <div className="text-xs text-[#64748b]">Audio đang phát — tập trung nghe và ghi đáp án.</div>
+          </div>
+        </section>
+
+        <section className="bg-white rounded-3xl border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] flex flex-col overflow-hidden max-h-[calc(100vh-220px)]">
+          {active && (
+            <>
+              <div className="px-6 py-4 border-b-2 border-[#e6e6ed] flex items-center justify-between bg-gradient-to-r from-[#fff1f2] to-white">
+                <div className="flex items-center gap-3">
+                  <div className="w-12 h-12 rounded-2xl bg-[#6366f1] text-white shadow-[0_3px_0_#4338ca] flex items-center justify-center text-lg font-black">{active.displayNum}</div>
+                  <div>
+                    <div className="text-[10px] font-bold uppercase tracking-wider text-[#64748b]">Question {active.displayNum} of {totalQuestions}</div>
+                    <div className="text-sm font-extrabold text-[#1e1b4b]">
+                      {active.type === 'MCQ' && 'Multiple choice'}
+                      {active.type === 'FILL_BLANK' && 'Fill in the blank'}
+                      {active.type === 'MATCHING' && 'Matching'}
+                      {active.type === 'LABELING' && 'Labeling'}
+                    </div>
+                  </div>
+                </div>
+                <button onClick={() => toggleFlag(active.id)} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-extrabold uppercase tracking-wide transition-all ${activeState === 'flagged' ? 'bg-[#fb7185] text-white shadow-[0_2px_0_#e11d48]' : 'bg-white text-[#64748b] border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#fb7185] hover:text-[#fb7185]'}`}>
+                  <span>🚩</span>
+                  <span>{activeState === 'flagged' ? 'Đã đánh dấu' : 'Đánh dấu'}</span>
+                </button>
+              </div>
+
+              <div className="overflow-y-auto p-6 flex-1">
+                <AnimatePresence mode="wait">
+                  <motion.div key={active.id} initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }} transition={{ duration: 0.18 }}>
+                    <p className="text-base font-semibold text-[#1e1b4b] leading-relaxed mb-5">{active.prompt}</p>
+
+                    {active.type === 'MCQ' && active.options?.length > 0 && (
+                      <div className="space-y-2.5">
+                        {active.options.map((opt, idx) => {
+                          const letter = String.fromCharCode(65 + idx);
+                          return <MCQOption key={idx} letter={letter} text={opt} selected={answers[active.id] === letter} onClick={() => setAnswer(active.id, letter)} />;
+                        })}
+                      </div>
+                    )}
+
+                    {active.type === 'FILL_BLANK' && (
+                      <div className="space-y-3">
+                        <label className="text-xs font-bold uppercase tracking-wide text-[#64748b]">Câu trả lời (NO MORE THAN TWO WORDS AND/OR A NUMBER)</label>
+                        <input
+                          value={answers[active.id] || ''}
+                          onChange={(e) => setAnswer(active.id, e.target.value)}
+                          placeholder="Type while listening..."
+                          className="w-full px-4 py-3.5 rounded-2xl border-2 border-[#e6e6ed] focus:border-[#6366f1] focus:shadow-[0_0_0_4px_rgba(99,102,241,0.18)] bg-white font-semibold outline-none transition-all text-lg"
+                        />
+                        <div className="text-xs text-[#64748b]">💡 Tự động lưu sau 1.5s</div>
+                      </div>
+                    )}
+
+                    {active.type === 'MATCHING' && active.options?.length > 0 && (
+                      <MatchingQuestion
+                        question={active}
+                        options={active.options}
+                        value={answers[active.id]}
+                        onChange={(v) => setAnswer(active.id, v)}
+                      />
+                    )}
+
+                    {active.type === 'LABELING' && (
+                      <LabelingQuestion
+                        question={active}
+                        options={active.wordBank || active.options}
+                        imageUrl={active.imageUrl}
+                        value={answers[active.id]}
+                        onChange={(v) => setAnswer(active.id, v)}
+                      />
+                    )}
+                  </motion.div>
+                </AnimatePresence>
+              </div>
+
+              <div className="border-t-2 border-[#e6e6ed] p-4 flex items-center gap-3 bg-[#fafafc]">
+                <StackedButton tone="ghost" onClick={goPrev}>← Câu trước</StackedButton>
+                <div className="flex-1 text-center text-xs font-bold text-[#64748b]">
+                  {activeState === 'answered' ? <span className="text-[#10b981]">✓ Đã lưu</span> : 'Chưa trả lời'}
+                </div>
+                <StackedButton tone="indigo" onClick={goNext}>Câu sau →</StackedButton>
+              </div>
+            </>
+          )}
+        </section>
+
+        <aside className="space-y-4 lg:sticky lg:top-[160px] lg:self-start">
+          <div className="bg-white rounded-3xl border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-extrabold text-[#1e1b4b]">Question Palette</h3>
+              <span className="text-[10px] font-bold uppercase tracking-wide text-[#64748b]">{questions[0]?.id} - {questions[questions.length - 1]?.id}</span>
+            </div>
+            <div className="grid grid-cols-5 gap-1.5 mb-4">
+              {questions.map((q) => (
+                <PaletteCell key={q.id} num={q.displayNum} state={getState(q.id)} active={q.id === activeId} onClick={() => setActiveId(q.id)} />
+              ))}
+            </div>
+            <div className="space-y-2 text-xs">
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-md bg-[#eef2ff] border-2 border-[#a5b4fc]" />
+                <span className="text-[#64748b]">Đã trả lời ({answeredCount})</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-md bg-[#fff1f2] border-2 border-[#fb7185]" />
+                <span className="text-[#64748b]">Đã đánh dấu ({Object.values(flagged).filter(Boolean).length})</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-gradient-to-br from-[#06b6d4] to-[#0891b2] text-white rounded-3xl shadow-[0_3px_0_#0e7490] p-4">
+            <div className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider opacity-90 mb-2">
+              <span>👂</span> Mẹo Listening
+            </div>
+            <div className="text-sm font-semibold leading-relaxed">
+              Đọc trước câu hỏi 30 giây để biết cần nghe key word nào.
+            </div>
+          </div>
+        </aside>
+      </main>
+    </div>
+  );
+};
+
+export default IELTSListeningTestScreen;

--- a/src/components/magicpath/ielts-reading-test-screen/IELTSReadingTestScreen.jsx
+++ b/src/components/magicpath/ielts-reading-test-screen/IELTSReadingTestScreen.jsx
@@ -1,0 +1,510 @@
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { createManyAnswersAPI, FinistTestAPI } from '@/services/apiDoTest';
+import { buildLegacyAnswerForAdapter } from '@/services/contractAdapters';
+import { toast } from 'react-toastify';
+
+const TONE_STYLES = {
+  indigo: 'bg-[#6366f1] text-white shadow-[0_4px_0_#4338ca] hover:brightness-110',
+  cyan: 'bg-[#06b6d4] text-white shadow-[0_4px_0_#0891b2] hover:brightness-110',
+  coral: 'bg-[#fb7185] text-white shadow-[0_4px_0_#e11d48] hover:brightness-110',
+  amber: 'bg-[#f59e0b] text-white shadow-[0_4px_0_#b45309] hover:brightness-110',
+  ghost: 'bg-white text-[#6366f1] border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]',
+};
+const SIZE_STYLES = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-5 py-2.5 text-sm',
+  lg: 'px-7 py-3.5 text-base',
+};
+
+function StackedButton({ children, tone = 'indigo', onClick, className = '', size = 'md', disabled }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`${TONE_STYLES[tone]} ${SIZE_STYLES[size]} font-extrabold uppercase tracking-wide rounded-2xl active:translate-y-[2px] active:shadow-[0_2px_0] transition-all disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function PaletteCell({ num, state, active, onClick }) {
+  const base = 'relative w-9 h-9 rounded-xl text-sm font-extrabold transition-all border-2';
+  let cls = '';
+  if (active) cls = 'bg-[#6366f1] text-white border-[#4338ca] shadow-[0_3px_0_#4338ca] scale-110';
+  else if (state === 'flagged') cls = 'bg-[#fff1f2] text-[#e11d48] border-[#fb7185] shadow-[0_2px_0_#e11d48]';
+  else if (state === 'answered') cls = 'bg-[#eef2ff] text-[#4338ca] border-[#a5b4fc] shadow-[0_2px_0_#a5b4fc]';
+  else cls = 'bg-white text-[#64748b] border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]';
+  return (
+    <button onClick={onClick} className={`${base} ${cls}`}>
+      {num}
+      {state === 'flagged' && <span className="absolute -top-1 -right-1 w-3 h-3 bg-[#fb7185] rounded-full ring-2 ring-white" />}
+    </button>
+  );
+}
+
+function MCQOption({ letter, text, selected, onClick }) {
+  return (
+    <button onClick={onClick} className={`w-full flex items-start gap-3 p-3.5 rounded-2xl border-2 text-left transition-all ${selected ? 'bg-[#eef2ff] border-[#6366f1] shadow-[0_2px_0_#4338ca]' : 'bg-white border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]'}`}>
+      <div className={`flex-none w-9 h-9 rounded-xl flex items-center justify-center font-black ${selected ? 'bg-[#6366f1] text-white' : 'bg-[#f1f1f6] text-[#64748b]'}`}>{letter}</div>
+      <div className="flex-1 pt-1.5 text-sm font-semibold text-[#1e1b4b]">{text}</div>
+      {selected && <div className="text-[#6366f1] text-lg pt-1">✓</div>}
+    </button>
+  );
+}
+
+function TFNGOption({ value, selected, onClick }) {
+  const colors = {
+    TRUE: { bg: 'bg-[#10b981]', shadow: 'shadow-[0_3px_0_#047857]' },
+    FALSE: { bg: 'bg-[#fb7185]', shadow: 'shadow-[0_3px_0_#e11d48]' },
+    'NOT GIVEN': { bg: 'bg-[#64748b]', shadow: 'shadow-[0_3px_0_#334155]' },
+  };
+  return (
+    <button onClick={onClick} className={`flex-1 px-4 py-3 rounded-2xl font-extrabold text-xs uppercase tracking-wide transition-all border-2 ${selected ? `${colors[value].bg} ${colors[value].shadow} text-white border-transparent` : 'bg-white text-[#1e1b4b] border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]'}`}>
+      {value}
+    </button>
+  );
+}
+
+function YesNoNotGivenOption({ value, selected, onClick }) {
+  const colors = {
+    YES: { bg: 'bg-[#06b6d4]', shadow: 'shadow-[0_3px_0_#0e7490]' },
+    NO: { bg: 'bg-[#fb7185]', shadow: 'shadow-[0_3px_0_#e11d48]' },
+    'NOT GIVEN': { bg: 'bg-[#64748b]', shadow: 'shadow-[0_3px_0_#334155]' },
+  };
+  return (
+    <button onClick={onClick} className={`flex-1 px-4 py-3 rounded-2xl font-extrabold text-xs uppercase tracking-wide transition-all border-2 ${selected ? `${colors[value].bg} ${colors[value].shadow} text-white border-transparent` : 'bg-white text-[#1e1b4b] border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]'}`}>
+      {value}
+    </button>
+  );
+}
+
+function MatchingQuestion({ question, options, value, onChange }) {
+  const letters = options.map((_, i) => String.fromCharCode(65 + i));
+  return (
+    <div className="space-y-4">
+      <div className="bg-[#eef2ff] border-2 border-[#a5b4fc] rounded-2xl p-4">
+        <div className="text-[10px] font-bold uppercase tracking-wider text-[#6366f1] mb-2">Word bank</div>
+        <div className="flex flex-wrap gap-2">
+          {options.map((opt, idx) => (
+            <div key={idx} className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-xl bg-white border-2 border-[#a5b4fc]">
+              <span className="w-5 h-5 rounded-md bg-[#6366f1] text-white text-[10px] font-black flex items-center justify-center">{String.fromCharCode(65 + idx)}</span>
+              <span className="text-xs font-semibold text-[#1e1b4b]">{opt.text || opt.matching_key}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <label className="text-xs font-bold uppercase tracking-wide text-[#64748b]">Chọn đáp án</label>
+        <div className="flex flex-wrap gap-2">
+          {options.map((_, idx) => {
+            const letter = String.fromCharCode(65 + idx);
+            const selected = value === letter;
+            return (
+              <button key={letter} onClick={() => onChange(letter)} className={`w-12 h-12 rounded-2xl font-black text-sm transition-all border-2 ${selected ? 'bg-[#6366f1] text-white border-[#4338ca] shadow-[0_3px_0_#4338ca]' : 'bg-white text-[#1e1b4b] border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]'}`}>
+                {letter}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LabelingQuestion({ question, options, imageUrl, value, onChange }) {
+  return (
+    <div className="space-y-4">
+      {imageUrl && (
+        <div className="bg-[#fafafc] border-2 border-[#e6e6ed] rounded-2xl p-3 flex items-center justify-center">
+          <img src={imageUrl} alt="diagram" className="max-w-full max-h-80 object-contain" />
+        </div>
+      )}
+      <div className="bg-[#eef2ff] border-2 border-[#a5b4fc] rounded-2xl p-4">
+        <div className="text-[10px] font-bold uppercase tracking-wider text-[#6366f1] mb-2">Word bank</div>
+        <div className="flex flex-wrap gap-2">
+          {options.map((opt, idx) => (
+            <div key={idx} className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-xl bg-white border-2 border-[#a5b4fc]">
+              <span className="w-5 h-5 rounded-md bg-[#6366f1] text-white text-[10px] font-black flex items-center justify-center">{opt.matching_key || String.fromCharCode(65 + idx)}</span>
+              <span className="text-xs font-semibold text-[#1e1b4b]">{opt.text || opt.answer_text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <label className="text-xs font-bold uppercase tracking-wide text-[#64748b]">Chọn nhãn</label>
+        <select value={value || ''} onChange={(e) => onChange(e.target.value)} className="w-full px-4 py-3.5 rounded-2xl border-2 border-[#e6e6ed] focus:border-[#6366f1] focus:shadow-[0_0_0_4px_rgba(99,102,241,0.18)] bg-white font-semibold outline-none transition-all">
+          <option value="">— Chọn —</option>
+          {options.map((opt, idx) => {
+            const key = opt.matching_key || String.fromCharCode(65 + idx);
+            return <option key={idx} value={key}>{key}. {opt.text || opt.answer_text}</option>;
+          })}
+        </select>
+      </div>
+    </div>
+  );
+}
+
+const fmt = (s) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+
+export const IELTSReadingTestScreen = ({ testData, testResultId, userId, initialAnswers, onSubmitSuccess }) => {
+  // Normalize passages + questions
+  const passages = useMemo(() => {
+    const parts = testData?.parts || [];
+    if (parts.length === 0) {
+      return [{ id: 1, title: testData?.title || 'Passage', content: testData?.content || '', questionIds: (testData?.questions || []).map((q) => q.id || q.questionNumber) }];
+    }
+    return parts.map((p, idx) => {
+      const groupQs = (p?.questionGroups || []).flatMap((g) => g?.questions || g?.question || []);
+      return {
+        id: p.id ?? idx + 1,
+        title: p?.passage?.title || p.title || `Passage ${idx + 1}`,
+        content: p?.passage?.content || p.content || p.text || '',
+        questionIds: groupQs.map((q) => q.id || q.questionNumber),
+      };
+    });
+  }, [testData]);
+
+  const questions = useMemo(() => {
+    const parts = testData?.parts || [];
+    const flat = parts.flatMap((p) =>
+      (p?.questionGroups || []).flatMap((g) => g?.questions || g?.question || [])
+    );
+    return flat.map((q, idx) => {
+      // Word bank cho MATCHING/LABELING từ g.answers[]
+      const wordBank = (q.answers || []).map((a) => ({
+        text: a.answer_text || a.text || '',
+        matching_key: a.matching_key || a.label || '',
+      }));
+      // options ưu tiên q.options, fallback word bank
+      const options = (q.options && q.options.length > 0)
+        ? q.options
+        : wordBank;
+      return {
+        id: q.id || q.questionNumber || idx + 1,
+        displayNum: idx + 1,
+        type: q.type || q.questionType || 'MCQ',
+        prompt: q.prompt || q.content || q.questionText || '',
+        options,
+        wordBank,
+        imageUrl: q.imageUrl || null,
+        answer: q.userAnswer || '',
+        passageId: q.passageId || null,
+      };
+    });
+  }, [testData]);
+
+  const totalQuestions = questions.length;
+  const totalSeconds = (testData?.durationMinutes || 60) * 60;
+  const passageOf = useCallback((qid) => {
+    const q = questions.find((x) => x.id === qid);
+    if (!q) return passages[0]?.id;
+    if (q.passageId) return q.passageId;
+    // fallback: tìm passage có chứa questionId
+    for (const p of passages) {
+      if (p.questionIds.includes(qid)) return p.id;
+    }
+    return passages[0]?.id;
+  }, [questions, passages]);
+
+  const [answers, setAnswers] = useState(() => {
+    const init = {};
+    const seed = initialAnswers || {};
+    questions.forEach((q) => {
+      const val = seed[q.id] ?? seed[String(q.id)] ?? q.answer;
+      if (val) init[q.id] = val;
+    });
+    return init;
+  });
+  const [flagged, setFlagged] = useState({});
+  const [activeId, setActiveId] = useState(questions[0]?.id || 1);
+  const [secondsLeft, setSecondsLeft] = useState(totalSeconds);
+  const [highlightSentence, setHighlightSentence] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const autosaveRef = useRef(null);
+
+  // Timer
+  useEffect(() => {
+    if (secondsLeft <= 0) {
+      handleSubmit();
+      return;
+    }
+    const t = setInterval(() => setSecondsLeft((s) => s - 1), 1000);
+    return () => clearInterval(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [secondsLeft]);
+
+  // Build legacy-shape answer items the contract adapter can convert.
+  // Each question's `type` (legacy alias or backend enum) drives the payload shape.
+  // Defined BEFORE the autosave useEffect that depends on it.
+  const answersToLegacyPayload = useCallback(() => {
+    return Object.entries(answers)
+      .map(([qid, val]) => {
+        const q = questions.find((x) => x.id === qid || x.id === Number(qid) || String(x.id) === qid);
+        return buildLegacyAnswerForAdapter(qid, val, q?.type);
+      })
+      .filter(Boolean);
+  }, [answers, questions]);
+
+  // Autosave
+  useEffect(() => {
+    if (!testResultId || !userId) return;
+    if (autosaveRef.current) clearTimeout(autosaveRef.current);
+    autosaveRef.current = setTimeout(() => {
+      const payload = answersToLegacyPayload();
+      if (payload.length === 0) return;
+      createManyAnswersAPI(userId, testResultId, { answers: payload }).catch((e) => {
+        console.warn('autosave failed', e);
+      });
+    }, 1500);
+    return () => { if (autosaveRef.current) clearTimeout(autosaveRef.current); };
+  }, [answers, testResultId, userId, answersToLegacyPayload]);
+
+  const setAnswer = useCallback((qid, val) => {
+    setAnswers((prev) => ({ ...prev, [qid]: val }));
+  }, []);
+
+  const toggleFlag = useCallback((qid) => {
+    setFlagged((prev) => ({ ...prev, [qid]: !prev[qid] }));
+  }, []);
+
+  const getState = useCallback((qid) => {
+    if (flagged[qid]) return 'flagged';
+    if (answers[qid]) return 'answered';
+    return 'unanswered';
+  }, [flagged, answers]);
+
+  const active = questions.find((q) => q.id === activeId);
+  const activeState = active ? getState(active.id) : 'unanswered';
+  const activePassage = passages.find((p) => p.id === passageOf(activeId));
+  const answeredCount = Object.keys(answers).filter((k) => answers[k]).length;
+  const progress = totalQuestions ? (answeredCount / totalQuestions) * 100 : 0;
+  const minutes = Math.floor(secondsLeft / 60);
+  const secs = secondsLeft % 60;
+  const timeWarn = secondsLeft < 5 * 60;
+
+  const goNext = () => {
+    const idx = questions.findIndex((q) => q.id === activeId);
+    if (idx < questions.length - 1) setActiveId(questions[idx + 1].id);
+  };
+  const goPrev = () => {
+    const idx = questions.findIndex((q) => q.id === activeId);
+    if (idx > 0) setActiveId(questions[idx - 1].id);
+  };
+
+  const handleSubmit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const payload = answersToLegacyPayload();
+      const result = await FinistTestAPI(testResultId, userId, {
+        answers: payload,
+        duration: totalSeconds - secondsLeft,
+      });
+      toast.success('Nộp bài thành công!');
+      if (onSubmitSuccess) onSubmitSuccess(result);
+    } catch (e) {
+      console.error('submit failed', e);
+      toast.error('Nộp bài thất bại. Vui lòng thử lại.');
+      setSubmitting(false);
+    }
+  };
+
+  // Render passage content (HTML) — strip HTML tags cho highlight target,
+  // nhưng render bằng dangerouslySetInnerHTML để giữ thẻ <p><strong>...
+  const renderedPassage = useMemo(() => {
+    if (!activePassage?.content) return null;
+    return { __html: activePassage.content };
+  }, [activePassage]);
+
+  if (!testData || questions.length === 0) {
+    return <div className="min-h-screen flex items-center justify-center text-[#64748b]">Không có câu hỏi nào.</div>;
+  }
+
+  return (
+    <div className="min-h-screen w-full bg-[#fafafc] flex flex-col">
+      <header className="sticky top-0 z-30 bg-white/95 backdrop-blur border-b-2 border-[#e6e6ed]">
+        <div className="max-w-[1440px] mx-auto px-6 py-3 flex items-center gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-2xl bg-gradient-to-br from-[#6366f1] to-[#a855f7] shadow-[0_3px_0_#4338ca] flex items-center justify-center text-lg">🦉</div>
+            <div className="hidden sm:block">
+              <div className="text-[10px] font-bold uppercase tracking-wider text-[#64748b]">IELTS Reading</div>
+              <div className="text-sm font-extrabold text-[#1e1b4b]">{testData?.title || 'Test'}</div>
+            </div>
+          </div>
+
+          <div className="flex-1 min-w-[200px] max-w-md mx-auto">
+            <div className="flex items-center gap-2 text-xs font-bold text-[#64748b] mb-1.5">
+              <span>{answeredCount}/{totalQuestions} đã trả lời</span>
+              <span className="ml-auto text-[#6366f1]">{Math.round(progress)}%</span>
+            </div>
+            <div className="h-2.5 bg-[#f1f1f6] rounded-full overflow-hidden">
+              <motion.div animate={{ width: `${progress}%` }} className="h-full bg-gradient-to-r from-[#6366f1] via-[#06b6d4] to-[#fb7185] rounded-full" />
+            </div>
+          </div>
+
+          <div className={`flex items-center gap-2 px-4 py-2 rounded-2xl font-mono font-black text-lg border-2 ${timeWarn ? 'bg-[#fff1f2] text-[#e11d48] border-[#fb7185] shadow-[0_3px_0_#e11d48] animate-pulse' : 'bg-[#eef2ff] text-[#4338ca] border-[#a5b4fc] shadow-[0_3px_0_#a5b4fc]'}`}>
+            <span>⏱</span>
+            <span>{String(minutes).padStart(2, '0')}:{String(secs).padStart(2, '0')}</span>
+          </div>
+
+          <StackedButton tone="coral" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? 'Đang nộp...' : 'Nộp bài'}
+          </StackedButton>
+        </div>
+      </header>
+
+      <main className="flex-1 max-w-[1440px] w-full mx-auto px-6 py-6 grid grid-cols-1 lg:grid-cols-[1fr_1fr_240px] gap-6">
+        <section className="bg-white rounded-3xl border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] flex flex-col overflow-hidden max-h-[calc(100vh-120px)]">
+          <div className="px-6 py-4 border-b-2 border-[#e6e6ed] flex items-center justify-between bg-gradient-to-r from-[#eef2ff] to-white">
+            <div>
+              <div className="text-[10px] font-bold uppercase tracking-wider text-[#6366f1]">{activePassage?.title || 'Passage'}</div>
+              <h2 className="text-xl font-black text-[#1e1b4b]" style={{ fontFamily: 'Nunito' }}>{activePassage?.title || 'Reading Passage'}</h2>
+            </div>
+            <div className="flex gap-2">
+              <button onClick={() => setHighlightSentence((h) => !h)} className="w-9 h-9 rounded-xl bg-white border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#f59e0b] flex items-center justify-center text-sm" title="Highlight">✏️</button>
+            </div>
+          </div>
+          <div className="overflow-y-auto p-6 text-[15px] leading-[1.85] text-[#1e1b4b]" style={{ fontFamily: 'Plus Jakarta Sans' }} dangerouslySetInnerHTML={renderedPassage} />
+        </section>
+
+        <section className="bg-white rounded-3xl border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] flex flex-col overflow-hidden max-h-[calc(100vh-120px)]">
+          {active && (
+            <>
+              <div className="px-6 py-4 border-b-2 border-[#e6e6ed] flex items-center justify-between bg-gradient-to-r from-[#fff1f2] to-white">
+                <div className="flex items-center gap-3">
+                  <div className="w-12 h-12 rounded-2xl bg-[#6366f1] text-white shadow-[0_3px_0_#4338ca] flex items-center justify-center text-lg font-black">{active.displayNum}</div>
+                  <div>
+                    <div className="text-[10px] font-bold uppercase tracking-wider text-[#64748b]">Question {active.displayNum} of {totalQuestions}</div>
+                    <div className="text-sm font-extrabold text-[#1e1b4b]">
+                      {active.type === 'MCQ' && 'Multiple choice'}
+                      {active.type === 'TFNG' && 'True / False / Not given'}
+                      {active.type === 'FILL_BLANK' && 'Fill in the blank'}
+                      {active.type === 'SHORT_ANSWER' && 'Short answer'}
+                      {active.type === 'MATCHING' && 'Matching'}
+                      {active.type === 'LABELING' && 'Labeling'}
+                      {active.type === 'YES_NO_NOTGIVEN' && 'Yes / No / Not given'}
+                    </div>
+                  </div>
+                </div>
+                <button onClick={() => toggleFlag(active.id)} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-extrabold uppercase tracking-wide transition-all ${activeState === 'flagged' ? 'bg-[#fb7185] text-white shadow-[0_2px_0_#e11d48]' : 'bg-white text-[#64748b] border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#fb7185] hover:text-[#fb7185]'}`}>
+                  <span>🚩</span>
+                  <span>{activeState === 'flagged' ? 'Đã đánh dấu' : 'Đánh dấu'}</span>
+                </button>
+              </div>
+
+              <div className="overflow-y-auto p-6 flex-1">
+                <AnimatePresence mode="wait">
+                  <motion.div key={active.id} initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }} transition={{ duration: 0.18 }}>
+                    <p className="text-base font-semibold text-[#1e1b4b] leading-relaxed mb-5">{active.prompt}</p>
+
+                    {active.type === 'MCQ' && active.options?.length > 0 && (
+                      <div className="space-y-2.5">
+                        {active.options.map((opt, idx) => {
+                          const letter = String.fromCharCode(65 + idx);
+                          return <MCQOption key={idx} letter={letter} text={opt} selected={answers[active.id] === letter} onClick={() => setAnswer(active.id, letter)} />;
+                        })}
+                      </div>
+                    )}
+
+                    {active.type === 'TFNG' && (
+                      <div className="flex gap-2">
+                        {['TRUE', 'FALSE', 'NOT GIVEN'].map((v) => <TFNGOption key={v} value={v} selected={answers[active.id] === v} onClick={() => setAnswer(active.id, v)} />)}
+                      </div>
+                    )}
+
+                    {active.type === 'FILL_BLANK' && (
+                      <div className="space-y-2">
+                        <label className="text-xs font-bold uppercase tracking-wide text-[#64748b]">Câu trả lời của bạn</label>
+                        <input value={answers[active.id] || ''} onChange={(e) => setAnswer(active.id, e.target.value)} placeholder="Type ONE WORD ONLY" className="w-full px-4 py-3.5 rounded-2xl border-2 border-[#e6e6ed] focus:border-[#6366f1] focus:shadow-[0_0_0_4px_rgba(99,102,241,0.18)] bg-white font-semibold outline-none transition-all" />
+                        <div className="text-xs text-[#64748b]">💡 Đáp án phải đúng chính tả và viết thường</div>
+                      </div>
+                    )}
+
+                    {active.type === 'SHORT_ANSWER' && (
+                      <div className="space-y-2">
+                        <label className="text-xs font-bold uppercase tracking-wide text-[#64748b]">Câu trả lời (NO MORE THAN THREE WORDS)</label>
+                        <textarea value={answers[active.id] || ''} onChange={(e) => setAnswer(active.id, e.target.value)} rows={3} placeholder="Type your answer here..." className="w-full px-4 py-3.5 rounded-2xl border-2 border-[#e6e6ed] focus:border-[#6366f1] focus:shadow-[0_0_0_4px_rgba(99,102,241,0.18)] bg-white font-semibold outline-none transition-all resize-none" />
+                      </div>
+                    )}
+
+                    {active.type === 'YES_NO_NOTGIVEN' && (
+                      <div className="flex gap-2">
+                        {['YES', 'NO', 'NOT GIVEN'].map((v) => (
+                          <YesNoNotGivenOption key={v} value={v} selected={answers[active.id] === v} onClick={() => setAnswer(active.id, v)} />
+                        ))}
+                      </div>
+                    )}
+
+                    {active.type === 'MATCHING' && active.options?.length > 0 && (
+                      <MatchingQuestion
+                        question={active}
+                        options={active.options}
+                        value={answers[active.id]}
+                        onChange={(v) => setAnswer(active.id, v)}
+                      />
+                    )}
+
+                    {active.type === 'LABELING' && (
+                      <LabelingQuestion
+                        question={active}
+                        options={active.wordBank || active.options}
+                        imageUrl={active.imageUrl}
+                        value={answers[active.id]}
+                        onChange={(v) => setAnswer(active.id, v)}
+                      />
+                    )}
+                  </motion.div>
+                </AnimatePresence>
+              </div>
+
+              <div className="border-t-2 border-[#e6e6ed] p-4 flex items-center gap-3 bg-[#fafafc]">
+                <StackedButton tone="ghost" onClick={goPrev}>← Câu trước</StackedButton>
+                <div className="flex-1 text-center text-xs font-bold text-[#64748b]">
+                  {activeState === 'answered' ? '✓ Đã lưu' : 'Chưa trả lời'}
+                </div>
+                <StackedButton tone="indigo" onClick={goNext}>Câu sau →</StackedButton>
+              </div>
+            </>
+          )}
+        </section>
+
+        <aside className="space-y-4 lg:sticky lg:top-[88px] lg:self-start">
+          <div className="bg-white rounded-3xl border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-extrabold text-[#1e1b4b]">Bản đồ câu hỏi</h3>
+              <span className="text-[10px] font-bold uppercase tracking-wide text-[#64748b]">{totalQuestions} câu</span>
+            </div>
+            <div className="grid grid-cols-5 gap-1.5 mb-4">
+              {questions.map((q) => <PaletteCell key={q.id} num={q.displayNum} state={getState(q.id)} active={q.id === activeId} onClick={() => setActiveId(q.id)} />)}
+            </div>
+            <div className="space-y-2 text-xs">
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-md bg-[#eef2ff] border-2 border-[#a5b4fc]" />
+                <span className="text-[#64748b]">Đã trả lời ({answeredCount})</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-md bg-[#fff1f2] border-2 border-[#fb7185]" />
+                <span className="text-[#64748b]">Đã đánh dấu ({Object.values(flagged).filter(Boolean).length})</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-md bg-white border-2 border-[#e6e6ed]" />
+                <span className="text-[#64748b]">Chưa trả lời ({questions.filter((q) => getState(q.id) === 'unanswered').length})</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-[#fff1f2] border-2 border-[#fb7185]/30 rounded-3xl p-4">
+            <div className="text-xs font-bold uppercase tracking-wide text-[#e11d48] mb-1">⚠️ Mẹo</div>
+            <div className="text-sm font-semibold text-[#1e1b4b] leading-relaxed">
+              Đừng dừng quá lâu ở 1 câu. Đánh dấu rồi quay lại sau khi xong các câu dễ.
+            </div>
+          </div>
+        </aside>
+      </main>
+    </div>
+  );
+};
+
+export default IELTSReadingTestScreen;

--- a/src/components/magicpath/ielts-writing-test-screen/IELTSWritingTestScreen.jsx
+++ b/src/components/magicpath/ielts-writing-test-screen/IELTSWritingTestScreen.jsx
@@ -1,0 +1,238 @@
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { createWritingSubmissionAPI } from '@/services/apiWriting';
+import { FinishTestWritingAPI } from '@/services/apiDoTest';
+import { toast } from 'react-toastify';
+
+const TONE_STYLES = {
+  indigo: 'bg-[#6366f1] text-white shadow-[0_4px_0_#4338ca] hover:brightness-110',
+  cyan: 'bg-[#06b6d4] text-white shadow-[0_4px_0_#0891b2] hover:brightness-110',
+  coral: 'bg-[#fb7185] text-white shadow-[0_4px_0_#e11d48] hover:brightness-110',
+  amber: 'bg-[#f59e0b] text-white shadow-[0_4px_0_#b45309] hover:brightness-110',
+  ghost: 'bg-white text-[#6366f1] border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] hover:border-[#6366f1]',
+};
+const SIZE_STYLES = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-5 py-2.5 text-sm',
+  lg: 'px-7 py-3.5 text-base',
+};
+
+function StackedButton({ children, tone = 'indigo', onClick, size = 'md', disabled }) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`${TONE_STYLES[tone]} ${SIZE_STYLES[size]} font-extrabold uppercase tracking-wide rounded-2xl active:translate-y-[2px] active:shadow-[0_2px_0] transition-all disabled:opacity-50 disabled:cursor-not-allowed`}
+    >
+      {children}
+    </button>
+  );
+}
+
+const fmt = (s) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+
+export const IELTSWritingTestScreen = ({ testData, testResultId, userId, writingTasks, initialAnswers, onSubmitSuccess }) => {
+  // tasks: từ props hoặc testData
+  const tasks = useMemo(() => {
+    const raw = writingTasks || testData?.writingTasks || [];
+    if (raw.length === 0) {
+      return [
+        { id: 1, title: 'Task 1', prompt: 'No task available.', minWords: 150, imageUrl: null },
+        { id: 2, title: 'Task 2', prompt: 'No task available.', minWords: 250, imageUrl: null },
+      ];
+    }
+    return raw.map((t, idx) => ({
+      id: t.id ?? idx + 1,
+      title: t.title || (idx === 0 ? 'Task 1' : 'Task 2'),
+      prompt: t.description || t.prompt || t.content || '',
+      minWords: t.minWords || (idx === 0 ? 150 : 250),
+      imageUrl: t.imageUrl || t.image || null,
+    }));
+  }, [writingTasks, testData]);
+
+  const totalSeconds = (testData?.durationMinutes || 60) * 60;
+
+  const [texts, setTexts] = useState(() => {
+    const init = {};
+    const map = initialAnswers || {};
+    tasks.forEach((t) => {
+      // initialAnswers có thể map theo taskId (number) hoặc idWritingTask (string)
+      const seed = map[t.id] ?? map[String(t.id)] ?? map[t.idWritingTask] ?? map[String(t.idWritingTask)] ?? '';
+      init[t.id] = typeof seed === 'string' ? seed : (seed?.submissionText || seed?.text || '');
+    });
+    return init;
+  });
+  const [activeTaskId, setActiveTaskId] = useState(tasks[0]?.id || 1);
+  const [secondsLeft, setSecondsLeft] = useState(totalSeconds);
+  const [submitting, setSubmitting] = useState(false);
+  const autosaveRef = useRef(null);
+
+  const activeTask = tasks.find((t) => t.id === activeTaskId) || tasks[0];
+  const text = texts[activeTaskId] || '';
+  const isTask2 = activeTask.minWords >= 250;
+  const targetWords = activeTask.minWords;
+  const wordCount = useMemo(() => (text.trim() === '' ? 0 : text.trim().split(/\s+/).length), [text]);
+  const wordPct = Math.min(100, (wordCount / targetWords) * 100);
+
+  const setText = useCallback((val) => {
+    setTexts((prev) => ({ ...prev, [activeTaskId]: val }));
+  }, [activeTaskId]);
+
+  // Timer
+  useEffect(() => {
+    if (secondsLeft <= 0) {
+      handleSubmit();
+      return;
+    }
+    const t = setInterval(() => setSecondsLeft((s) => s - 1), 1000);
+    return () => clearInterval(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [secondsLeft]);
+
+  // Autosave (debounce 2s)
+  useEffect(() => {
+    if (!testResultId || !activeTaskId) return;
+    if (autosaveRef.current) clearTimeout(autosaveRef.current);
+    autosaveRef.current = setTimeout(() => {
+      const txt = texts[activeTaskId];
+      if (!txt) return;
+      createWritingSubmissionAPI(
+        {
+          idWritingTask: activeTaskId,
+          submissionText: txt,
+          wordCount,
+        },
+        testResultId
+      ).catch((e) => {
+        console.warn('autosave writing failed', e);
+      });
+    }, 2000);
+    return () => { if (autosaveRef.current) clearTimeout(autosaveRef.current); };
+  }, [texts, activeTaskId, testResultId, wordCount]);
+
+  const handleSubmit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const result = await FinishTestWritingAPI(testResultId, userId, {
+        writingSubmissions: tasks.map((t) => ({
+          idWritingTask: t.id,
+          submissionText: texts[t.id] || '',
+        })),
+        duration: totalSeconds - secondsLeft,
+      });
+      toast.success('Nộp bài thành công!');
+      if (onSubmitSuccess) onSubmitSuccess(result);
+    } catch (e) {
+      console.error('submit writing failed', e);
+      toast.error('Nộp bài thất bại. Vui lòng thử lại.');
+      setSubmitting(false);
+    }
+  };
+
+  if (!testData || tasks.length === 0) {
+    return <div className="min-h-screen flex items-center justify-center text-[#64748b]">Không có bài tập nào.</div>;
+  }
+
+  return (
+    <div className="min-h-screen w-full bg-[#fafafc] flex flex-col">
+      <header className="sticky top-0 z-30 bg-white/95 backdrop-blur border-b-2 border-[#e6e6ed]">
+        <div className="max-w-[1440px] mx-auto px-6 py-3 flex items-center gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-2xl bg-gradient-to-br from-[#6366f1] to-[#a855f7] shadow-[0_3px_0_#4338ca] flex items-center justify-center text-lg">🦉</div>
+            <div className="hidden sm:block">
+              <div className="text-[10px] font-bold uppercase tracking-wider text-[#64748b]">IELTS Writing</div>
+              <div className="text-sm font-extrabold text-[#1e1b4b]">{testData?.title || 'Test'}</div>
+            </div>
+          </div>
+
+          <div className="flex-1 flex justify-center min-w-[200px]">
+            <div className="flex bg-[#f1f1f6] rounded-2xl p-1">
+              {tasks.map((t, idx) => (
+                <button
+                  key={t.id}
+                  onClick={() => setActiveTaskId(t.id)}
+                  className={`px-5 py-2 rounded-xl text-sm font-extrabold uppercase tracking-wide transition-all ${activeTaskId === t.id ? 'bg-white text-[#6366f1] shadow-[0_2px_0_#e6e6ed]' : 'text-[#64748b]'}`}
+                >
+                  {t.title} · {t.minWords === 150 ? '20' : '40'} phút
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 px-4 py-2 rounded-2xl font-mono font-black text-lg bg-[#eef2ff] text-[#4338ca] border-2 border-[#a5b4fc] shadow-[0_3px_0_#a5b4fc]">
+            <span>⏱</span>
+            <span>{fmt(secondsLeft)}</span>
+          </div>
+
+          <StackedButton tone="coral" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? 'Đang nộp...' : 'Nộp bài'}
+          </StackedButton>
+        </div>
+      </header>
+
+      <main className="flex-1 max-w-[1440px] w-full mx-auto px-6 py-6 grid grid-cols-1 lg:grid-cols-[1fr_1.4fr_280px] gap-6">
+        <section className="space-y-4 lg:sticky lg:top-[88px] lg:self-start">
+          <div className="bg-white rounded-3xl border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] overflow-hidden">
+            <div className="px-5 py-3 bg-gradient-to-r from-[#eef2ff] to-white border-b-2 border-[#e6e6ed] flex items-center gap-2">
+              <div className="w-7 h-7 rounded-lg bg-[#6366f1] text-white flex items-center justify-center text-xs font-black">{tasks.findIndex((t) => t.id === activeTaskId) + 1}</div>
+              <div className="text-sm font-extrabold text-[#1e1b4b]">{activeTask.title}</div>
+              <span className="ml-auto text-[10px] font-bold uppercase tracking-wider text-[#64748b]">≥ {targetWords} words</span>
+            </div>
+            <div className="p-5 text-sm text-[#1e1b4b] leading-relaxed whitespace-pre-line" style={{ fontFamily: 'Plus Jakarta Sans' }}>
+              {activeTask.prompt}
+            </div>
+            {activeTask.imageUrl && (
+              <div className="px-5 pb-5">
+                <img src={activeTask.imageUrl} alt="task figure" className="rounded-2xl border-2 border-[#e6e6ed] w-full" />
+              </div>
+            )}
+          </div>
+
+          <div className="bg-white rounded-3xl border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] p-5">
+            <div className="text-[10px] font-bold uppercase tracking-wider text-[#6366f1] mb-2">📝 Dàn bài gợi ý</div>
+            <ol className="space-y-1.5 text-xs">
+              {(isTask2
+                ? ['Introduction + thesis', 'Body 1: View A + lý do', 'Body 2: View B + lý do', 'Conclusion + opinion']
+                : ['Paraphrase đề', 'Overview 2-3 ý lớn', 'Body 1: chi tiết nhóm 1', 'Body 2: chi tiết nhóm 2']
+              ).map((step, i) => (
+                <li key={i} className="flex items-center gap-2 px-3 py-2 rounded-xl bg-[#fafafc]">
+                  <div className="w-5 h-5 rounded-md bg-[#6366f1] text-white flex items-center justify-center text-[10px] font-black">{i + 1}</div>
+                  <span className="font-semibold text-[#1e1b4b]">{step}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section className="bg-white rounded-3xl border-2 border-[#e6e6ed] shadow-[0_2px_0_#e6e6ed] flex flex-col overflow-hidden max-h-[calc(100vh-120px)]">
+          <div className="px-4 py-2.5 border-b-2 border-[#e6e6ed] flex items-center justify-end gap-2 bg-[#fafafc]">
+            <span className="text-xs font-bold text-[#64748b]">{wordCount} / {targetWords} từ</span>
+            <div className="w-24 h-2 bg-[#f1f1f6] rounded-full overflow-hidden">
+              <motion.div animate={{ width: `${wordPct}%` }} className={`h-full rounded-full ${wordCount >= targetWords ? 'bg-gradient-to-r from-[#10b981] to-[#06b6d4]' : 'bg-gradient-to-r from-[#fb7185] to-[#f59e0b]'}`} />
+            </div>
+          </div>
+
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={isTask2 ? 'Mở bài bằng cách giới thiệu chủ đề...' : 'Bắt đầu paraphrase đề bài...'}
+            className="flex-1 px-8 py-6 outline-none resize-none text-base leading-[1.85] text-[#1e1b4b] placeholder-[#94a3b8] bg-white"
+            style={{ fontFamily: 'Plus Jakarta Sans' }}
+          />
+        </section>
+
+        <aside className="space-y-4 lg:sticky lg:top-[88px] lg:self-start">
+          <div className="bg-[#fef3c7] border-2 border-[#f59e0b]/30 rounded-3xl p-4">
+            <div className="text-xs font-bold uppercase tracking-wide text-[#b45309] mb-1">⚠️ Mẹo</div>
+            <div className="text-sm font-semibold text-[#1e1b4b] leading-relaxed">
+              {isTask2 ? 'Trình bày quan điểm rõ ràng, có thesis statement ở introduction.' : 'Không đưa ý kiến cá nhân — chỉ mô tả số liệu trên biểu đồ.'}
+            </div>
+          </div>
+        </aside>
+      </main>
+    </div>
+  );
+};
+
+export default IELTSWritingTestScreen;

--- a/src/services/apiDoTest.js
+++ b/src/services/apiDoTest.js
@@ -145,6 +145,13 @@ export const DeleteTestResultAPI = async (idTestResult) => {
   return res.data;
 };
 
+export const findAllTestResultByIdUserAPI = async (idUser) => {
+  const res = await API.get(
+    `/user-test-result/get-all-test-result-by-id-user/${idUser}`
+  );
+  return normalizeEnvelope(res.data, normalizeTestResultDataForLegacy);
+};
+
 export const getTestResultByIdAPI = async (idTestResult) => {
   const res = await API.get(
     `/user-test-result/get-test-result/${idTestResult}`

--- a/src/services/contractAdapters.js
+++ b/src/services/contractAdapters.js
@@ -847,6 +847,55 @@ export const mapLegacyAnswerToSubmitItem = (answer, fallbackLegacyType = null) =
   };
 };
 
+/**
+ * Build a legacy-shape answer from a { qid, val, questionType } triplet
+ * so that mapLegacyAnswerToSubmitItem can convert it. This is the shape
+ * that the magicpath test screens must emit for autosave/submit.
+ *
+ * - MCQ / MATCHING / LABELING: emits { matching_key: val, userAnswerType }
+ * - TFNG / YES_NO_NOT_GIVEN: emits { matching_value: val, userAnswerType }
+ * - Fill-in (SENTENCE_COMPLETION, SUMMARY_COMPLETION, ...): emits { answerText, userAnswerType }
+ *
+ * `qid` may be a number or string — it will be stringified.
+ * `userAnswerType` may be either a backend enum (TRUE_FALSE_NOT_GIVEN) or
+ * a legacy alias (TFNG, MCQ, FILL_BLANK, MATCHING, LABELING) — the
+ * adapter normalizes both forms.
+ */
+export const buildLegacyAnswerForAdapter = (qid, val, userAnswerType) => {
+  const idQuestion = toStringSafe(qid);
+  if (!idQuestion || val === undefined || val === null || val === "") {
+    return null;
+  }
+
+  const base = { idQuestion, userAnswerType };
+  const normalized = toStringSafe(userAnswerType).trim().toUpperCase();
+
+  // Selected a letter/index → matching_key (MCQ + all MATCHING_*)
+  if (
+    normalized === "MCQ" ||
+    normalized === "MULTIPLE_CHOICE" ||
+    normalized === "MATCHING" ||
+    normalized.startsWith("MATCHING_") ||
+    normalized === "LABELING" ||
+    normalized === "DIAGRAM_LABELING"
+  ) {
+    return { ...base, matching_key: toStringSafe(val) };
+  }
+
+  // Picked an answer label like TRUE / FALSE / NOT GIVEN / YES / NO
+  if (
+    normalized === "TFNG" ||
+    normalized === "TRUE_FALSE_NOT_GIVEN" ||
+    normalized === "YES_NO_NOT_GIVEN" ||
+    normalized === "YES_NO_NOTGIVEN"
+  ) {
+    return { ...base, matching_value: toStringSafe(val) };
+  }
+
+  // Free text answer
+  return { ...base, answerText: toStringSafe(val) };
+};
+
 export const mapLegacyAnswersToSubmitItems = (answers, fallbackTypeMap = {}) => {
   const grouped = new Map();
 


### PR DESCRIPTION
…re-doing finished tests

Three related fixes for the Listening/Reading/Writing magicpath test screens:

1. contractAdapters.js — add buildLegacyAnswerForAdapter(qid, val, userAnswerType) helper. The adapter's mapLegacyAnswerToSubmitItem reads idQuestion + userAnswerType + matching_key/answerText/matching_value. The magicpath screens were emitting {questionId, answer} which the adapter rejected (no idQuestion) and dropped every answer before reaching the BE, so submit ended up with answers: [] and score = 0.

2. IELTSReadingTestScreen.jsx, IELTSListeningTestScreen.jsx — both autosave and handleSubmit now go through answersToLegacyPayload() which looks up each question's type and emits the correct legacy shape (matching_key for MCQ/MATCHING/LABELING, matching_value for TFNG/YES_NO_NOT_GIVEN, answerText for fill-in).

3. IELTSWritingTestScreen.jsx — payload key was 'submissions' but the BE DTO FinishTestWritingDto expects 'writingSubmissions', so the BE's finishTestWriting block (which enqueues AI grading) was skipped entirely. Renamed.

4. apiDoTest.js — export findAllTestResultByIdUserAPI(idUser) so the test screen can pre-flight the user's history.

5. Pages/client/test/doTest.jsx — when the user lands on /do-test/:id via deep link or browser back, we now query the user's test history, sort by createdAt desc, and if the latest testResult for this idTest is FINISHED, show a blocking Modal with the score and finishedAt. Without this, the screen mounted, autosave fired against a status=FINISHED testResult, and the BE returned 400 'This test has already been submitted'. IN_PROGRESS rows still allow resume — only the FINISHED latest row blocks.

Each call to startTest creates a brand new userTestResult row (BE does not upsert on (idUser, idTest)), so the 'latest by createdAt' logic correctly handles re-attempts where an IN_PROGRESS row is newer than a prior FINISHED row.

Bug score hardcoded to 0 for Writing/Speaking bandScore in userTestResult is documented in ielts_training_app/AI_GRADING_NOTES.md and intentionally NOT fixed here — touching the AI grading worker or Prisma schema is out of scope.